### PR TITLE
fix: poor performance of controlled components in docs due to repeate…

### DIFF
--- a/docs/js/Code.jsx
+++ b/docs/js/Code.jsx
@@ -24,10 +24,6 @@ export default class Code extends Component {
     this.childProperties = omit(properties, 'style');
   }
 
-  componentDidUpdate() {
-    highlightJs.highlightBlock(React.findDOMNode(this));
-  }
-
   render() {
     const style = extend({}, defaultStyle, this.props.style);
 

--- a/docs/js/Code.jsx
+++ b/docs/js/Code.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import highlightJs from 'highlight.js';
-import {omit, extend} from 'underscore';
+import {isEqual, omit, extend} from 'underscore';
 
 const defaultStyle = {
   fontFamily: 'Consolas, "Liberation Mono", Menlo, Courier, monospace',
@@ -22,6 +22,16 @@ export default class Code extends Component {
 
   componentWillReceiveProps(properties) {
     this.childProperties = omit(properties, 'style');
+  }
+
+  shouldComponentUpdate(nextProps) {
+    if (nextProps.value === this.props.value && isEqual(nextProps.style, this.props.style)) {
+      return false;
+    }
+  }
+
+  componentDidUpdate() {
+    highlightJs.highlightBlock(React.findDOMNode(this));
   }
 
   render() {


### PR DESCRIPTION
Hey @nikgraf ,

Can you check this change locally before u merge, this has definitely fixed the performance issue with TextInput.

But somehow I do not see highlighting in my local, with or without this fix (although http://nikgraf.github.io/belle/#/ has code highlighting). Can you confirm at your end if highlighting is intact after this change.