### PR TITLE
ComboBox: defaults children prop to empty array

### DIFF
--- a/src/components/ComboBox.jsx
+++ b/src/components/ComboBox.jsx
@@ -193,7 +193,8 @@ export default class ComboBox extends Component {
     enableHint: false,
     'aria-label': 'ComboBox',
     filterFunc: filterFunc,
-    tabIndex: 0
+    tabIndex: 0,
+    children: []
   };
 
   /**


### PR DESCRIPTION
prevents unhandled exception when no children options are supplied

fix #136