### PR TITLE
Select helper fixes

### DIFF
--- a/examples/js/SelectPlayground.jsx
+++ b/examples/js/SelectPlayground.jsx
@@ -52,6 +52,26 @@ export default React.createClass({
           <option value="C">Cranberry</option>
         </select>
 
+        <h3>Select with one option</h3>
+        <Select>
+          <Option value={ "vienna" }>Vienna</Option>
+        </Select>
+
+        <h3>Select with placeholder, option array combined and a single option combined.</h3>
+        <Select>
+          <Placeholder>Lala</Placeholder>
+          {
+            fruits.map((fruit) => {
+              return (
+                <Option value={ fruit.value }>
+                  { fruit.content }
+                </Option>
+              );
+            })
+          }
+          <Option value={ "newyork" }>New York</Option>
+        </Select>
+
         <h3>Select with onUpdate</h3>
         <Select onUpdate={ (event) => console.log(event.value) }>
           <Option value={ "vienna" }>Vienna</Option>

--- a/examples/js/SelectPlayground.jsx
+++ b/examples/js/SelectPlayground.jsx
@@ -61,9 +61,9 @@ export default React.createClass({
         <Select>
           <Placeholder>Lala</Placeholder>
           {
-            fruits.map((fruit) => {
+            fruits.map((fruit, index) => {
               return (
-                <Option value={ fruit.value }>
+                <Option key={ index } value={ fruit.value }>
                   { fruit.content }
                 </Option>
               );

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -46,8 +46,7 @@ const findIndexOfFocusedOption = (component) => {
  * Verifies that the provided property is an Option or Placeholder component from Belle.
  */
 function optionOrPlaceholderOrSeparatorPropType(props, propName, componentName) {
-  if (!(props[propName] &&
-        isOption(props[propName]) ||
+  if (props[propName] && !(isOption(props[propName]) ||
         isPlaceholder(props[propName]) ||
         isSeparator(props[propName]))
      ) {
@@ -218,7 +217,9 @@ export default class Select extends Component {
     let selectedValue;
     let focusedOptionValue;
 
-    this.children = flatten(properties.children);
+    if (properties.children) {
+      this.children = flatten(properties.children);
+    }
 
     if (has(properties, 'valueLink')) {
       selectedValue = properties.valueLink.value;

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {omit, extend, filter, find, first, isEmpty, findIndex, last, size, uniqueId, has, some} from '../utils/helpers';
+import {omit, extend, filter, find, first, flatten, isEmpty, findIndex, last, size, uniqueId, has, some} from '../utils/helpers';
 import unionClassNames from '../utils/union-class-names';
 import {injectStyles, removeStyle} from '../utils/inject-style';
 import style from '../style/select';
@@ -216,6 +216,8 @@ export default class Select extends Component {
     let selectedValue;
     let focusedOptionValue;
 
+    this.children = flatten(properties.children);
+
     if (has(properties, 'valueLink')) {
       selectedValue = properties.valueLink.value;
       focusedOptionValue = selectedValue;
@@ -307,6 +309,8 @@ export default class Select extends Component {
   }
 
   componentWillReceiveProps(properties) {
+    this.children = flatten(properties.children);
+
     const newState = {
       selectedOptionWrapperProps: sanitizeSelectedOptionWrapperProps(properties),
       wrapperProps: sanitizeWrapperProps(properties.wrapperProps),
@@ -357,7 +361,7 @@ export default class Select extends Component {
       const menuNode = React.findDOMNode(this.refs.menu);
 
       // the menu was just opened
-      if (!previousState.isOpen && this.state.isOpen && this.props.children && this.props.children.length > 0) {
+      if (!previousState.isOpen && this.state.isOpen && this.children && this.children.length > 0) {
         const positionOptions = has(this.props, 'positionOptions') ? this.props.positionOptions : config.positionOptions;
         positionOptions(this);
       // restore the old scrollTop position
@@ -365,8 +369,8 @@ export default class Select extends Component {
         menuNode.scrollTop = this.cachedMenuScrollTop;
       }
 
-      const options = filter(this.props.children, isOption);
-      const separators = filter(this.props.children, isSeparator);
+      const options = filter(this.children, isOption);
+      const separators = filter(this.children, isSeparator);
       const childrenLength = (options ? options.length : 0) + (separators ? separators.length : 0);
       if (!previousState.isOpen && this.state.isOpen && childrenLength) {
         const menuStyle = extend({}, style.menuStyle, this.props.menuStyle);
@@ -565,14 +569,14 @@ export default class Select extends Component {
     if (this.state.focusedOptionValue) {
       const indexOfFocusedOption = findIndexOfFocusedOption(this);
 
-      if (hasNext(filter(this.props.children, isOption), indexOfFocusedOption)) {
+      if (hasNext(filter(this.children, isOption), indexOfFocusedOption)) {
         this.setState({
-          focusedOptionValue: filter(this.props.children, isOption)[indexOfFocusedOption + 1].props.value
+          focusedOptionValue: filter(this.children, isOption)[indexOfFocusedOption + 1].props.value
         });
       }
     } else {
       this.setState({
-        focusedOptionValue: first(filter(this.props.children, isOption)).props.value
+        focusedOptionValue: first(filter(this.children, isOption)).props.value
       });
     }
   }
@@ -590,14 +594,14 @@ export default class Select extends Component {
     if (this.state.focusedOptionValue) {
       const indexOfFocusedOption = findIndexOfFocusedOption(this);
 
-      if (hasPrevious(filter(this.props.children, isOption), indexOfFocusedOption)) {
+      if (hasPrevious(filter(this.children, isOption), indexOfFocusedOption)) {
         this.setState({
-          focusedOptionValue: filter(this.props.children, isOption)[indexOfFocusedOption - 1].props.value
+          focusedOptionValue: filter(this.children, isOption)[indexOfFocusedOption - 1].props.value
         });
       }
     } else {
       this.setState({
-        focusedOptionValue: last(filter(this.props.children, isOption)).props.value
+        focusedOptionValue: last(filter(this.children, isOption)).props.value
       });
     }
   }
@@ -625,7 +629,7 @@ export default class Select extends Component {
    */
   _onKeyDown(event) {
     if (!this.props.disabled) {
-      if (filter(this.props.children, isOption).length > 0) {
+      if (filter(this.children, isOption).length > 0) {
         if (!this.state.isOpen) {
           if (event.key === 'ArrowDown' ||
               event.key === 'ArrowUp' ||
@@ -721,7 +725,7 @@ export default class Select extends Component {
 
     let selectedOptionOrPlaceholder;
     if (this.state.selectedValue) {
-      const selectedEntry = find(this.props.children, (entry) => {
+      const selectedEntry = find(this.children, (entry) => {
         return entry.props.value === this.state.selectedValue;
       });
 
@@ -731,11 +735,11 @@ export default class Select extends Component {
         });
       }
     } else {
-      selectedOptionOrPlaceholder = find(this.props.children, isPlaceholder);
+      selectedOptionOrPlaceholder = find(this.children, isPlaceholder);
     }
 
-    const options = filter(this.props.children, isOption);
-    const separators = filter(this.props.children, isSeparator);
+    const options = filter(this.children, isOption);
+    const separators = filter(this.children, isSeparator);
     const childrenLength = (options ? options.length : 0) + (separators ? separators.length : 0);
     const computedMenuStyle = this.props.disabled || !this.state.isOpen || childrenLength === 0 ? { display: 'none' } : menuStyle;
     const hasCustomTabIndex = this.props.wrapperProps && this.props.wrapperProps.tabIndex;
@@ -803,7 +807,7 @@ export default class Select extends Component {
             ref="menu"
             {...this.state.menuProps} >
           {
-            React.Children.map(this.props.children, (entry, index) => {
+            React.Children.map(this.children, (entry, index) => {
               if (isOption(entry)) { // filter out all non-Option Components
                 const isHovered = entry.props.value === this.state.focusedOptionValue;
                 const option = React.cloneElement(entry, {

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -217,14 +217,18 @@ export default class Select extends Component {
     let focusedOptionValue;
 
     if (has(properties, 'valueLink')) {
-      focusedOptionValue = selectedValue = properties.valueLink.value;
+      selectedValue = properties.valueLink.value;
+      focusedOptionValue = selectedValue;
     } else if (has(properties, 'value')) {
-      focusedOptionValue = selectedValue = properties.value;
+      selectedValue = properties.value;
+      focusedOptionValue = selectedValue;
     } else if (has(properties, 'defaultValue')) {
-      focusedOptionValue = selectedValue = properties.defaultValue;
+      selectedValue = properties.defaultValue;
+      focusedOptionValue = selectedValue;
     } else if (!isEmpty(properties.children) && !some(properties.children, isPlaceholder)) {
       const firstOption = first(filter(properties.children, isOption));
-      focusedOptionValue = selectedValue = firstOption ? firstOption.props.value : void 0;
+      selectedValue = firstOption ? firstOption.props.value : void 0;
+      focusedOptionValue = selectedValue;
     } else if (!isEmpty(properties.children)) {
       const firstOption = first(filter(properties.children, isOption));
       focusedOptionValue = firstOption ? firstOption.props.value : void 0;
@@ -359,6 +363,14 @@ export default class Select extends Component {
       // restore the old scrollTop position
       } else {
         menuNode.scrollTop = this.cachedMenuScrollTop;
+      }
+
+      const options = filter(this.props.children, isOption);
+      const separators = filter(this.props.children, isSeparator);
+      const childrenLength = (options ? options.length : 0) + (separators ? separators.length : 0);
+      if (!previousState.isOpen && this.state.isOpen && childrenLength) {
+        const menuStyle = extend({}, style.menuStyle, this.props.menuStyle);
+        menuNode.style.display = menuStyle.display;
       }
     }
   }
@@ -701,7 +713,7 @@ export default class Select extends Component {
     const focusStyle = extend({}, defaultStyle, style.focusStyle, this.props.focusStyle);
     const disabledStyle = extend({}, defaultStyle, style.disabledStyle, this.props.disabledStyle);
     const disabledHoverStyle = extend({}, disabledStyle, style.disabledHoverStyle, this.props.disabledHoverStyle);
-    const menuStyle = extend({}, style.menuStyle, this.props.menuStyle, { display: 'block' });
+    const menuStyle = extend({}, style.menuStyle, this.props.menuStyle);
     const caretToCloseStyle = extend({}, style.caretToCloseStyle, this.props.caretToCloseStyle);
     const caretToOpenStyle = extend({}, style.caretToOpenStyle, this.props.caretToOpenStyle);
     const disabledCaretToOpenStyle = extend({}, caretToOpenStyle, style.disabledCaretToOpenStyle, this.props.disabledCaretToOpenStyle);

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -312,7 +312,9 @@ export default class Select extends Component {
   }
 
   componentWillReceiveProps(properties) {
-    this.children = flatten(properties.children);
+    if (properties.children) {
+      this.children = flatten(properties.children);
+    }
 
     const newState = {
       selectedOptionWrapperProps: sanitizeSelectedOptionWrapperProps(properties),

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component, PropTypes} from 'react';
 import {omit, extend, filter, find, first, flatten, isEmpty, findIndex, last, size, uniqueId, has, some} from '../utils/helpers';
 import unionClassNames from '../utils/union-class-names';
 import {injectStyles, removeStyle} from '../utils/inject-style';
@@ -37,7 +37,7 @@ function isSeparator(reactElement) {
  * The index search includes only option components.
  */
 const findIndexOfFocusedOption = (component) => {
-  return findIndex(filter(component.props.children, isOption), (element) => {
+  return findIndex(filter(component.children, isOption), (element) => {
     return element.props.value === component.state.focusedOptionValue;
   });
 };
@@ -59,11 +59,13 @@ function optionOrPlaceholderOrSeparatorPropType(props, propName, componentName) 
  * Verifies that the children is an array containing only Options & at maximum
  * one Placeholder.
  */
-function validateArrayOfOptionsAndMaximumOnePlaceholder(props, propName, componentName) {
-  const error = React.PropTypes.arrayOf(optionOrPlaceholderOrSeparatorPropType).isRequired(props, propName, componentName);
+function validateChildrenAreOptionsAndMaximumOnePlaceholder(props, propName, componentName) {
+  const sanitizedProps = { children: flatten(props[propName]) };
+
+  const error = PropTypes.arrayOf(optionOrPlaceholderOrSeparatorPropType).isRequired(sanitizedProps, 'children', componentName);
   if (error) return error;
 
-  const placeholders = filter(props[propName], isPlaceholder);
+  const placeholders = filter(sanitizedProps.children, isPlaceholder);
   if (size(placeholders) > 1) {
     return new Error(`Invalid children supplied to \`${componentName}\`, expected only one Placeholder component.`);
   }
@@ -227,12 +229,12 @@ export default class Select extends Component {
     } else if (has(properties, 'defaultValue')) {
       selectedValue = properties.defaultValue;
       focusedOptionValue = selectedValue;
-    } else if (!isEmpty(properties.children) && !some(properties.children, isPlaceholder)) {
-      const firstOption = first(filter(properties.children, isOption));
+    } else if (!isEmpty(this.children) && !some(this.children, isPlaceholder)) {
+      const firstOption = first(filter(this.children, isOption));
       selectedValue = firstOption ? firstOption.props.value : void 0;
       focusedOptionValue = selectedValue;
-    } else if (!isEmpty(properties.children)) {
-      const firstOption = first(filter(properties.children, isOption));
+    } else if (!isEmpty(this.children)) {
+      const firstOption = first(filter(this.children, isOption));
       focusedOptionValue = firstOption ? firstOption.props.value : void 0;
     }
 
@@ -253,44 +255,44 @@ export default class Select extends Component {
   static displayName = 'Belle Select';
 
   static propTypes = {
-    children: validateArrayOfOptionsAndMaximumOnePlaceholder,
-    value: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
-      React.PropTypes.number,
-      React.PropTypes.instanceOf(Date)
+    children: validateChildrenAreOptionsAndMaximumOnePlaceholder,
+    value: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.instanceOf(Date)
     ]),
-    defaultValue: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.string,
-      React.PropTypes.number
+    defaultValue: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string,
+      PropTypes.number
     ]),
-    onUpdate: React.PropTypes.func,
-    valueLink: React.PropTypes.shape({
-      value: React.PropTypes.string.isRequired,
-      requestChange: React.PropTypes.func.isRequired
+    onUpdate: PropTypes.func,
+    valueLink: PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      requestChange: PropTypes.func.isRequired
     }),
-    className: React.PropTypes.string,
-    shouldPositionOptions: React.PropTypes.bool,
-    positionOptions: React.PropTypes.func,
-    style: React.PropTypes.object,
-    focusStyle: React.PropTypes.object,
-    hoverStyle: React.PropTypes.object,
-    wrapperStyle: React.PropTypes.object,
-    menuStyle: React.PropTypes.object,
-    caretToOpenStyle: React.PropTypes.object,
-    caretToCloseStyle: React.PropTypes.object,
-    wrapperProps: React.PropTypes.object,
-    menuProps: React.PropTypes.object,
-    caretProps: React.PropTypes.object,
-    disabled: React.PropTypes.bool,
-    disabledStyle: React.PropTypes.object,
-    disabledHoverStyle: React.PropTypes.object,
-    disabledCaretToOpenStyle: React.PropTypes.object,
-    onClick: React.PropTypes.func,
-    onTouchCancel: React.PropTypes.func,
-    onTouchEnd: React.PropTypes.func,
-    onTouchStart: React.PropTypes.func
+    className: PropTypes.string,
+    shouldPositionOptions: PropTypes.bool,
+    positionOptions: PropTypes.func,
+    style: PropTypes.object,
+    focusStyle: PropTypes.object,
+    hoverStyle: PropTypes.object,
+    wrapperStyle: PropTypes.object,
+    menuStyle: PropTypes.object,
+    caretToOpenStyle: PropTypes.object,
+    caretToCloseStyle: PropTypes.object,
+    wrapperProps: PropTypes.object,
+    menuProps: PropTypes.object,
+    caretProps: PropTypes.object,
+    disabled: PropTypes.bool,
+    disabledStyle: PropTypes.object,
+    disabledHoverStyle: PropTypes.object,
+    disabledCaretToOpenStyle: PropTypes.object,
+    onClick: PropTypes.func,
+    onTouchCancel: PropTypes.func,
+    onTouchEnd: PropTypes.func,
+    onTouchStart: PropTypes.func
   };
 
   static defaultProps = {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -70,23 +70,38 @@ export function keys(obj) {
 }
 
 /**
- * Returns a new array of values by mapping each value in list through a transformation function (predicate). If object is a not an array, predicate's arguments will be (value, key, list).
+ * Returns a new array of values by mapping each value in list through a transformation function (predicate).
  *
- * @param {object|array} obj - object to be based upon
- * @param {function} predicate - function returning the a new version of the entry
- * @param {object} [context] - context for the predicate function call
+ * @param {array} iterable - source iterable
+ * @param {function} predicate - function returning the transformed array entry
  */
-export function map(obj, predicate, context) {
+export function map(iterable, predicate) {
+  if (iterable) {
+    const result = [];
+    iterable.forEach((elm, index) => {
+      if (predicate) {
+        result[index] = predicate(elm);
+      }
+    });
+    return result;
+  }
+}
+
+/**
+ * Returns a new object by mapping each property in an object through a transformation function (predicate).
+ *
+ * @param {object} obj - object to be based upon
+ * @param {function} predicate - function to transform the property
+ */
+export function mapObject(obj, predicate) {
   if (obj) {
     const result = [];
-    const objKeys = !isArrayLike(obj) && keys(obj);
-    const length = (objKeys || obj).length;
-    for (let index = 0; index < length; index++) {
-      const currentKey = objKeys ? objKeys[index] : index;
+    const objKeys = keys(obj);
+    objKeys.forEach( (key, index) => {
       if (predicate) {
-        result[index] = predicate.call(context, obj[currentKey], currentKey);
+        result[index] = predicate(obj[key], key);
       }
-    }
+    });
     return result;
   }
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -12,7 +12,7 @@ export function has(obj, key) {
  * Return a copy of the object, filtered to omit the blacklisted keys (or array of keys).
  *
  * @param {object} obj - object the returned object is based on
- * @param {string[]} fields - the list of keys of the property to omit
+ * @param {string|string[]} fields - the key or list of keys of the property to omit
  */
 export function omit(obj, fields) {
   if (obj) {
@@ -27,39 +27,19 @@ export function omit(obj, fields) {
 }
 
 /**
- * The function will execute predicate for each object in iterable object passed. Its different from javascript forEach in ways:
- * 1. In case obj is undefined / null it will not break.
- * 2. In case obj is not iterable it will consider obj as single element array and iterate over it
- *    (unlike underscore it will not iterate over each field of the object).
+ * Looks through each value in the list, returning an array of all the values
+ * that pass a truth test (predicate).
  *
- * @param {object|array} obj - object to be iterated
- * @param {function} predicate - function to be called for each element in the object
+ * @param {array} iterable - the iterable object to be filtered
+ * @param {function} predicate - function returning true when provided with an entry as argument
+ * @param {object} [context] - context for the predicate function call
  */
-export function each(obj, predicate) {
-  if (obj) {
-    if (isArrayLike(obj)) {
-      obj.forEach((elm, index) => {
-        predicate.call(null, elm, index);
-      });
-    } else {
-      predicate.call(null, obj);
-    }
-  }
-}
-
-/**
- * Looks through each value in the list, returning an array of all the values that pass a truth test (predicate).
- * In case the parameter passed is not iterable, it will treat that object as array of single object.
- *
- * @param {array} obj - the object to be filtered
- * @param {function} predicate - function executed to check if some element should be filtered.
- */
-export function filter(obj, predicate) {
-  if (obj) {
+export function filter(iterable, predicate, context) {
+  if (iterable) {
     const result = [];
-    each(obj, (elm) => {
-      if (predicate && predicate.call(null, elm)) {
-        result.push(elm);
+    iterable.forEach((obj) => {
+      if (predicate && predicate.call(context, obj)) {
+        result.push(obj);
       }
     });
     return result;
@@ -67,7 +47,7 @@ export function filter(obj, predicate) {
 }
 
 /**
- * Returns true if the provided object is iterable, except for strings for which it will return false.
+ * Returns true if the provided object is an iterable, except for strings for which it will return false.
  *
  * @param {object} obj - object to be inspected
  */
@@ -79,7 +59,7 @@ export function isArrayLike(obj) {
 }
 
 /**
- * Returns all the names of the object's own properties (this will not include properties inherited through prototypes).
+ * Returns all the names of the object's own properties. This will not include properties inherited through prototypes.
  *
  * @param {object} obj - object to be used
  */
@@ -90,63 +70,43 @@ export function keys(obj) {
 }
 
 /**
- * Returns a new array of values by mapping each value in list through a transformation function (predicate).
- * In case the parameter passed is not iterable, it will treat that object as array of single object.
+ * Returns a new array of values by mapping each value in list through a transformation function (predicate). If object is a not an array, predicate's arguments will be (value, key, list).
  *
  * @param {object|array} obj - object to be based upon
  * @param {function} predicate - function returning the a new version of the entry
+ * @param {object} [context] - context for the predicate function call
  */
-export function map(obj, predicate) {
+export function map(obj, predicate, context) {
   if (obj) {
     const result = [];
-    each(obj, (elm, index) => {
+    const objKeys = !isArrayLike(obj) && keys(obj);
+    const length = (objKeys || obj).length;
+    for (let index = 0; index < length; index++) {
+      const currentKey = objKeys ? objKeys[index] : index;
       if (predicate) {
-        result[index] = predicate.call(null, elm);
+        result[index] = predicate.call(context, obj[currentKey], currentKey);
       }
-    });
+    }
     return result;
   }
 }
 
 /**
- * Returns a new array of values by mapping each field in ab object through a transformation function (predicate).
- * The specific use-case for this method was inject-style module.
+ * Returns the first value that passes a truth test (predicate), or undefined if
+ * no value passes the test. Only works for iterable objects e.g. arrays.
  *
- * @param {object} obj - object to be based upon
- * @param {function} predicate - function returning the a new version of the entry
- */
-export function mapObject(obj, predicate) {
-  if (obj) {
-    const result = [];
-    const objKeys = keys(obj);
-    objKeys.forEach( (key, index) => {
-      if (predicate) {
-        result[index] = predicate.call(null, obj[key], key);
-      }
-    });
-    return result;
-  }
-}
-
-/**
- * Returns the first value that passes a truth test (predicate), or undefined if no value passes the test.
- * In case the parameter passed is not iterable, it will treat that object as array of single object.
- *
- * @param {object/array} obj - the object to be searched
+ * @param {array} iterable - the iterable object to be searched
  * @param {function} predicate - function returning true in case of a positive match
+ * @param {object} [context] - context for the predicate function call
  */
-export function find(obj, predicate) {
-  if (obj) {
+export function find(iterable, predicate, context) {
+  if (iterable) {
     let result;
-    if (isArrayLike(obj)) {
-      for (let index = 0; index < obj.length; index++) {
-        if (predicate && predicate.call(null, obj[index])) {
-          result = obj[index];
-          break;
-        }
+    for (let index = 0; index < iterable.length; index++) {
+      if (predicate && predicate.call(context, iterable[index])) {
+        result = iterable[index];
+        break;
       }
-    } else {
-      result = predicate && predicate.call(null, obj) ? obj : undefined;
     }
     return result;
   }
@@ -163,24 +123,20 @@ export function isEmpty(iterable) {
 
 /**
  * Returns the index of the first value that passes a truth test (predicate), or undefined if
- * no value passes the test.
- * In case the parameter passed is not iterable the function will execute predicate for it considering it to be a single element array.
+ * no value passes the test. Only works for iterable objects e.g. arrays.
  *
- * @param {object/array} obj - the object to be searched
+ * @param {array} iterable - the iterable object to be searched
  * @param {function} predicate - function returning true in case of a positive match
+ * @param {object} [context] - context for the predicate function call
  */
-export function findIndex(obj, predicate) {
-  if (obj) {
+export function findIndex(iterable, predicate, context) {
+  if (iterable) {
     let result;
-    if (isArrayLike(obj)) {
-      for (let index = 0; index < obj.length; index++) {
-        if (predicate && predicate.call(null, obj[index])) {
-          result = index;
-          break;
-        }
+    for (let index = 0; index < iterable.length; index++) {
+      if (predicate && predicate.call(context, iterable[index])) {
+        result = index;
+        break;
       }
-    } else {
-      result = predicate && predicate.call(null, obj) ? 0 : undefined;
     }
     return result;
   }
@@ -188,75 +144,53 @@ export function findIndex(obj, predicate) {
 
 /**
  * Returns the first element of an iterable object.
- * In case a single object is passed as parameter the function will return the object as is.
  *
- * @param {object/array} obj - the object to be searched
+ * @param {array} iterable - must be an iterable object
  */
-export function first(obj) {
-  if (obj) {
-    if (isArrayLike(obj)) {
-      if (obj.length > 0) {
-        return obj[0];
-      }
-    } else {
-      return obj;
-    }
+export function first(iterable) {
+  if (iterable && iterable.length > 0) {
+    return iterable[0];
   }
 }
 
 /**
  * Returns the last element of an iterable object.
- * In case a single object is passed as parameter the function will return the object as is.
  *
- * @param {object/array} obj - object to be searched.
+ * @param {array} iterable - must be an iterable object
  */
-export function last(obj) {
-  if (obj) {
-    if (isArrayLike(obj)) {
-      if (obj.length > 0) {
-        return obj[obj.length - 1];
-      }
-    } else {
-      return obj;
-    }
+export function last(iterable) {
+  if (iterable && iterable.length > 0) {
+    return iterable[iterable.length - 1];
   }
 }
 
 /**
  * Return the number of values in the list.
- * For non-iterable objects it will return 1.
  *
- * @param {object/array} obj
+ * @param {array} iterable - must be an iterable object
  */
-export function size(obj) {
-  if (obj) {
-    if (isArrayLike(obj)) {
-      return obj.length;
-    }
-    return 1;
+export function size(iterable) {
+  if (iterable) {
+    return iterable.length;
   }
   return 0;
 }
 
 /**
  * Returns true if any of the values in the list pass the predicate truth test.
- * In case the parameter passed is not iterable the function will execute predicate for it considering it to be a single element array.
  *
- * @param {object/array} obj - object object to be searched
+ * @param {array} iterable - iterable object to be searched
  * @param {function} predicate - function returning true in case of a positive match
+ * @param {object} [context] - context for the predicate function call
  */
-export function some(obj, predicate) {
-  if (obj) {
-    let result = false;
-    if (isArrayLike(obj)) {
-      for (let index = 0; index < obj.length; index++) {
-        if (predicate && predicate.call(null, obj[index])) {
-          result = true;
-          break;
-        }
+export function some(iterable, predicate, context) {
+  if (iterable) {
+    let result;
+    for (let index = 0; index < iterable.length; index++) {
+      if (predicate && predicate.call(context, iterable[index])) {
+        result = true;
+        break;
       }
-    } else {
-      result = predicate && predicate.call(null, obj) ? true : false;
     }
     return result;
   }
@@ -265,14 +199,14 @@ export function some(obj, predicate) {
 /**
  * Returns the union of the passed-in arrays: the list of unique items, in order, that are present in one or more of the arrays.
  *
- * @param {...array} arrs - >=1 objects to be merged.
+ * @param {...array} arrs - at least two iterable objects must be provide
  */
 export function union(...arrs) {
   if (arrs) {
     const result = [];
     arrs.forEach((arr) => {
       if (arr) {
-        each(arr, (obj) => {
+        arr.forEach((obj) => {
           if (result.indexOf(obj) < 0) {
             result.push(obj);
           }
@@ -305,11 +239,11 @@ export function extend(obj1, ...objs) {
   if (obj1 && objs) {
     objs.forEach((obj) => {
       if (obj) {
-        each(keys(obj), (key) => {
+        for (const key in obj) {
           if (obj.hasOwnProperty(key)) {
             obj1[key] = obj[key];
           }
-        });
+        }
       }
     });
   }
@@ -324,7 +258,7 @@ export function extend(obj1, ...objs) {
  */
 function flattenInternal(output, element) {
   if (element) {
-    each(element, (obj) => {
+    element.forEach((obj) => {
       if (Array.isArray(obj)) {
         flattenInternal(output, obj);
       } else {

--- a/src/utils/inject-style.js
+++ b/src/utils/inject-style.js
@@ -1,4 +1,4 @@
-import {flatten, map} from '../utils/helpers';
+import {flatten, mapObject} from '../utils/helpers';
 import CSSPropertyOperations from 'react/lib/CSSPropertyOperations';
 import { canUseDOM } from 'react/lib/ExecutionEnvironment';
 import animations from '../style/animations';
@@ -35,7 +35,7 @@ function updateStore(styleId, style, pseudoClass, disabled) {
  * Constructs all the stored styles & injects them to the DOM.
  */
 function createMarkupOnPseudoClass(pseudoClasses, id, disabled) {
-  return map(pseudoClasses, (style, pseudoClass) => {
+  return mapObject(pseudoClasses, (style, pseudoClass) => {
     const styleString = CSSPropertyOperations.createMarkupForStyles(style);
     const styleWithImportant = styleString.replace(/;/g, ' !important;');
 
@@ -46,7 +46,7 @@ function createMarkupOnPseudoClass(pseudoClasses, id, disabled) {
 }
 
 function updateStyling() {
-  const styles = map(styleStorage, (storageEntry, id) => {
+  const styles = mapObject(styleStorage, (storageEntry, id) => {
     const pseudoClassesArray = [];
 
     if (storageEntry.pseudoClasses) {

--- a/src/utils/inject-style.js
+++ b/src/utils/inject-style.js
@@ -1,4 +1,4 @@
-import {map, flatten} from '../utils/helpers';
+import {mapObject, flatten} from '../utils/helpers';
 import CSSPropertyOperations from 'react/lib/CSSPropertyOperations';
 import { canUseDOM } from 'react/lib/ExecutionEnvironment';
 import animations from '../style/animations';
@@ -35,7 +35,7 @@ function updateStore(styleId, style, pseudoClass, disabled) {
  * Constructs all the stored styles & injects them to the DOM.
  */
 function createMarkupOnPseudoClass(pseudoClasses, id, disabled) {
-  return map(pseudoClasses, (style, pseudoClass) => {
+  return mapObject(pseudoClasses, (style, pseudoClass) => {
     const styleString = CSSPropertyOperations.createMarkupForStyles(style);
     const styleWithImportant = styleString.replace(/;/g, ' !important;');
 
@@ -46,7 +46,7 @@ function createMarkupOnPseudoClass(pseudoClasses, id, disabled) {
 }
 
 function updateStyling() {
-  const styles = map(styleStorage, (storageEntry, id) => {
+  const styles = mapObject(styleStorage, (storageEntry, id) => {
     const pseudoClassesArray = [];
 
     if (storageEntry.pseudoClasses) {

--- a/src/utils/inject-style.js
+++ b/src/utils/inject-style.js
@@ -1,4 +1,4 @@
-import {mapObject, flatten} from '../utils/helpers';
+import {flatten, map} from '../utils/helpers';
 import CSSPropertyOperations from 'react/lib/CSSPropertyOperations';
 import { canUseDOM } from 'react/lib/ExecutionEnvironment';
 import animations from '../style/animations';
@@ -35,7 +35,7 @@ function updateStore(styleId, style, pseudoClass, disabled) {
  * Constructs all the stored styles & injects them to the DOM.
  */
 function createMarkupOnPseudoClass(pseudoClasses, id, disabled) {
-  return mapObject(pseudoClasses, (style, pseudoClass) => {
+  return map(pseudoClasses, (style, pseudoClass) => {
     const styleString = CSSPropertyOperations.createMarkupForStyles(style);
     const styleWithImportant = styleString.replace(/;/g, ' !important;');
 
@@ -46,7 +46,7 @@ function createMarkupOnPseudoClass(pseudoClasses, id, disabled) {
 }
 
 function updateStyling() {
-  const styles = mapObject(styleStorage, (storageEntry, id) => {
+  const styles = map(styleStorage, (storageEntry, id) => {
     const pseudoClassesArray = [];
 
     if (storageEntry.pseudoClasses) {

--- a/src/utils/is-component-of-type.js
+++ b/src/utils/is-component-of-type.js
@@ -9,7 +9,8 @@
  * isComponentType('Autocomplete', this.props.children[0]);
  */
 export default function isComponentOfType(displayName, reactElement) {
-  return reactElement._isReactElement &&
+  return reactElement &&
+         reactElement._isReactElement &&
          reactElement.type &&
          reactElement.type.displayName === displayName;
 }

--- a/tests/__tests__/Select-test.jsx
+++ b/tests/__tests__/Select-test.jsx
@@ -101,8 +101,8 @@ describe('Select', () => {
       <Select>
         <Placeholder>Select a City</Placeholder>
         {
-          options.map((option) => {
-            return (<Option value={ option.value } >{ option.content }</Option>);
+          options.map((option, index) => {
+            return (<Option key={ index } value={ option.value } >{ option.content }</Option>);
           })
         }
       </Select>
@@ -127,8 +127,8 @@ describe('Select', () => {
         <Placeholder>Select a City</Placeholder>
         <Option value="boston">Boston</Option>
         {
-          options.map((option) => {
-            return (<Option value={ option.value } >{ option.content }</Option>);
+          options.map((option, index) => {
+            return (<Option key={ index } value={ option.value } >{ option.content }</Option>);
           })
         }
         <Option value="newyork">New York</Option>

--- a/tests/__tests__/Select-test.jsx
+++ b/tests/__tests__/Select-test.jsx
@@ -80,6 +80,71 @@ describe('Select', () => {
     expect(selectedOptionArea.props.children[0]._store.props.children).toBe('Select a City');
   });
 
+  it('should work with one option provided', () => {
+    const select = TestUtils.renderIntoDocument(
+      <Select>
+        <Option value="rome">Rome</Option>
+      </Select>
+    );
+
+    const selectedOptionArea = TestUtils.scryRenderedDOMComponentsWithTag(select, 'div')[1];
+    expect(selectedOptionArea.props.children[0]._store.props.children).toBe('Rome');
+  });
+
+  it('should work with a placehoder and an array of options provided', () => {
+    const options = [
+      { value: 'rome', content: 'Rome' },
+      { value: 'vienna', content: 'Vienna' }
+    ];
+
+    const select = TestUtils.renderIntoDocument(
+      <Select>
+        <Placeholder>Select a City</Placeholder>
+        {
+          options.map((option) => {
+            return (<Option value={ option.value } >{ option.content }</Option>);
+          })
+        }
+      </Select>
+    );
+
+    const selectedOptionArea = TestUtils.scryRenderedDOMComponentsWithTag(select, 'div')[1];
+    const entries = TestUtils.scryRenderedDOMComponentsWithTag(select, 'li');
+
+    expect(selectedOptionArea.props.children[0]._store.props.children).toBe('Select a City');
+    expect(entries[0].props.children._store.props.children).toBe('Rome');
+    expect(entries[1].props.children._store.props.children).toBe('Vienna');
+  });
+
+  it('should work with a placehoder and a combination of single options and an array of options provided', () => {
+    const options = [
+      { value: 'rome', content: 'Rome' },
+      { value: 'vienna', content: 'Vienna' }
+    ];
+
+    const select = TestUtils.renderIntoDocument(
+      <Select>
+        <Placeholder>Select a City</Placeholder>
+        <Option value="boston">Boston</Option>
+        {
+          options.map((option) => {
+            return (<Option value={ option.value } >{ option.content }</Option>);
+          })
+        }
+        <Option value="newyork">New York</Option>
+      </Select>
+    );
+
+    const selectedOptionArea = TestUtils.scryRenderedDOMComponentsWithTag(select, 'div')[1];
+    const entries = TestUtils.scryRenderedDOMComponentsWithTag(select, 'li');
+
+    expect(selectedOptionArea.props.children[0]._store.props.children).toBe('Select a City');
+    expect(entries[0].props.children._store.props.children).toBe('Boston');
+    expect(entries[1].props.children._store.props.children).toBe('Rome');
+    expect(entries[2].props.children._store.props.children).toBe('Vienna');
+    expect(entries[3].props.children._store.props.children).toBe('New York');
+  });
+
   it('should be able to provide a valueLink', () => {
     let wasCalled = false;
 

--- a/tests/__tests__/helpers-test.js
+++ b/tests/__tests__/helpers-test.js
@@ -83,10 +83,48 @@ describe('helpers omit method', () => {
 });
 
 
+describe('helpers each method', () => {
+  let count = 0;
+  const arr = [123, 'abc', () => {}, undefined];
+  const obj = 123;
+  const predicate = () => {
+    return count++;
+  };
+
+  it('should execute predicate for each element of array', () => {
+    count = 0;
+    helpers.each(arr, predicate);
+    expect(count).toBe(4);
+  });
+
+  it('should execute predicate if parameter passed is not array but simple object', () => {
+    count = 0;
+    helpers.each(obj, predicate);
+    expect(count).toBe(1);
+  });
+
+  it('should not alter original array', () => {
+    helpers.each(arr, predicate);
+    expect(arr.length).toBe(4);
+    expect(arr.indexOf(123)).toBe(0);
+  });
+});
+
+describe('helpers isArrayLike method', () => {
+  it('should return true for array', () => {
+    expect(helpers.isArrayLike([123, 'abc', () => {}, undefined])).toBeTruthy();
+  });
+
+  it('should return false for non-arrays', () => {
+    expect(helpers.isArrayLike(123)).toBeFalsy();
+    expect(helpers.isArrayLike('abc')).toBeFalsy();
+  });
+});
+
 describe('helpers filter method', () => {
   const arr = [123, 'abc', () => {}, undefined];
-  const predicate = (obj) => {
-    return obj !== 123;
+  const predicate = (object) => {
+    return object !== 123;
   };
 
   it('should filter out objects from iterable as per predicate', () => {
@@ -193,13 +231,19 @@ describe('helpers map method for object', () => {
 
 describe('helpers find method', () => {
   const arr = [123, 'abc', () => {}, undefined];
-  const predicate = (obj) => {
-    return typeof obj === 'number';
+  const obj = 100;
+  const predicate = (object) => {
+    return typeof object === 'number';
   };
 
   it('should find first numeric value in array', () => {
-    const obj = helpers.find(arr, predicate);
-    expect(obj).toBe(123);
+    const resultObj = helpers.find(arr, predicate);
+    expect(resultObj).toBe(123);
+  });
+
+  it('should execute predicate test if parameter passed is not an array but simple object', () => {
+    const resultObj = helpers.find(obj, predicate);
+    expect(resultObj).toBe(100);
   });
 
   it('should not alter original array', () => {
@@ -210,23 +254,23 @@ describe('helpers find method', () => {
 
   it('should not break if array is undefined or null or has length 0', () => {
     let arr2;
-    let obj = helpers.find(arr2, predicate);
-    expect(obj).toBeFalsy();
+    let resultObj = helpers.find(arr2, predicate);
+    expect(resultObj).toBeFalsy();
     arr2 = null;
-    obj = helpers.find(arr2, predicate);
-    expect(obj).toBeFalsy();
+    resultObj = helpers.find(arr2, predicate);
+    expect(resultObj).toBeFalsy();
     arr2 = [];
-    obj = helpers.find(arr2, predicate);
-    expect(obj).toBeFalsy();
+    resultObj = helpers.find(arr2, predicate);
+    expect(resultObj).toBeFalsy();
   });
 
   it('should not break if predicate is undefined or null', () => {
     let predicate2;
-    let obj = helpers.find(arr, predicate2);
-    expect(obj).toBeFalsy();
+    let resultObj = helpers.find(arr, predicate2);
+    expect(resultObj).toBeFalsy();
     predicate2 = null;
-    obj = helpers.find(arr, predicate2);
-    expect(obj).toBeFalsy();
+    resultObj = helpers.find(arr, predicate2);
+    expect(resultObj).toBeFalsy();
   });
 });
 
@@ -244,13 +288,19 @@ describe('helpers isEmpty method', () => {
 
 describe('helpers findIndex method', () => {
   const arr = [123, 'abc', () => {}, undefined];
-  const predicate = (obj) => {
-    return typeof obj === 'number';
+  const obj = 100;
+  const predicate = (object) => {
+    return typeof object === 'number';
   };
 
   it('should find index of first numeric value in array', () => {
     const index = helpers.findIndex(arr, predicate);
     expect(index).toBe(0);
+  });
+
+  it('should execute predicate test if parameter passed is not an array but simple object', () => {
+    const resultObj = helpers.findIndex(obj, predicate);
+    expect(resultObj).toBe(0);
   });
 
   it('should not alter original array', () => {
@@ -261,28 +311,28 @@ describe('helpers findIndex method', () => {
 
   it('should not break if array is undefined or null or has length 0', () => {
     let obj2;
-    let obj = helpers.findIndex(obj2, predicate);
-    expect(obj).toBeFalsy();
+    let resultObj = helpers.findIndex(obj2, predicate);
+    expect(resultObj).toBeFalsy();
     obj2 = null;
-    obj = helpers.findIndex(obj2, predicate);
-    expect(obj).toBeFalsy();
+    resultObj = helpers.findIndex(obj2, predicate);
+    expect(resultObj).toBeFalsy();
     obj2 = [];
-    obj = helpers.findIndex(obj2, predicate);
-    expect(obj).toBeFalsy();
+    resultObj = helpers.findIndex(obj2, predicate);
+    expect(resultObj).toBeFalsy();
   });
 
   it('should not break if predicate is undefined or null', () => {
     let predicate2;
-    let obj = helpers.findIndex(arr, predicate2);
-    expect(obj).toBeFalsy();
+    let resultObj = helpers.findIndex(arr, predicate2);
+    expect(resultObj).toBeFalsy();
     predicate2 = null;
-    obj = helpers.findIndex(arr, predicate);
-    expect(obj).toBeFalsy();
+    resultObj = helpers.findIndex(arr, predicate);
+    expect(resultObj).toBeFalsy();
   });
 
   it('should return undefined in case the entry could not be found', () => {
-    const customPredicate = (obj) => {
-      return obj === 567;
+    const customPredicate = (resultObj) => {
+      return resultObj === 567;
     };
     const index = helpers.findIndex(arr, customPredicate);
     expect(index).toBeUndefined();
@@ -294,6 +344,10 @@ describe('helpers first method', () => {
     expect(helpers.first([1, 2, 3])).toBe(1);
     expect(helpers.first([null, 1, 2, 3, null])).toBe(null);
     expect(helpers.first([undefined, 1, 2, 3])).toBe(undefined);
+  });
+
+  it('should work for non-array value and return the value itself', () => {
+    expect(helpers.first('abc')).toBe('abc');
   });
 
   it('should not break for empty array', () => {
@@ -315,11 +369,19 @@ describe('helpers last method', () => {
     expect(helpers.last(null)).toBeFalsy();
     expect(helpers.last([])).toBeFalsy();
   });
+
+  it('should work for non-array value and return the value itself', () => {
+    expect(helpers.last('abc')).toBe('abc');
+  });
 });
 
 describe('helpers size method', () => {
   it('should return size of an array', () => {
     expect(helpers.size([1, 2, 3])).toBe(3);
+  });
+
+  it('should return 0 for non-array argument', () => {
+    expect(helpers.size('abc')).toBe(1);
   });
 
   it('should not break for empty array', () => {
@@ -337,6 +399,11 @@ describe('helpers some method', () => {
 
   it('should return true is predicate is true for some element', () => {
     const result = helpers.some(arr, predicate);
+    expect(result).toBe(true);
+  });
+
+  it('should work well if argument is not array but simple object', () => {
+    const result = helpers.some(100, predicate);
     expect(result).toBe(true);
   });
 

--- a/tests/__tests__/helpers-test.js
+++ b/tests/__tests__/helpers-test.js
@@ -189,6 +189,33 @@ describe('helpers map method for arrays', () => {
   });
 });
 
+describe('helpers mapObject method', () => {
+  const obj = {five: 5, ten: 10, fifty: 50, hundred: 100};
+  const predicate = (value) => {
+    return value / 5;
+  };
+  const objIdTest = {50: 5, 100: 10, 500: 50, 1000: 100};
+  const predicateIdTest = (value, id) => {
+    return id / value;
+  };
+
+  it('should map to an output array as per predicate', () => {
+    const resultObj = helpers.mapObject(obj, predicate);
+    expect(resultObj[0]).toBe(1);
+    expect(resultObj[1]).toBe(2);
+    expect(resultObj[2]).toBe(10);
+    expect(resultObj[3]).toBe(20);
+  });
+
+  it('should pass second parameter value to predicate', () => {
+    const resultObj = helpers.mapObject(objIdTest, predicateIdTest);
+    expect(resultObj[0]).toBe(10);
+    expect(resultObj[1]).toBe(10);
+    expect(resultObj[2]).toBe(10);
+    expect(resultObj[3]).toBe(10);
+  });
+});
+
 describe('helpers find method', () => {
   const arr = [123, 'abc', () => {}, undefined];
   const obj = 100;

--- a/tests/__tests__/helpers-test.js
+++ b/tests/__tests__/helpers-test.js
@@ -82,34 +82,6 @@ describe('helpers omit method', () => {
   });
 });
 
-
-describe('helpers each method', () => {
-  let count = 0;
-  const arr = [123, 'abc', () => {}, undefined];
-  const obj = 123;
-  const predicate = () => {
-    return count++;
-  };
-
-  it('should execute predicate for each element of array', () => {
-    count = 0;
-    helpers.each(arr, predicate);
-    expect(count).toBe(4);
-  });
-
-  it('should execute predicate if parameter passed is not array but simple object', () => {
-    count = 0;
-    helpers.each(obj, predicate);
-    expect(count).toBe(1);
-  });
-
-  it('should not alter original array', () => {
-    helpers.each(arr, predicate);
-    expect(arr.length).toBe(4);
-    expect(arr.indexOf(123)).toBe(0);
-  });
-});
-
 describe('helpers isArrayLike method', () => {
   it('should return true for array', () => {
     expect(helpers.isArrayLike([123, 'abc', () => {}, undefined])).toBeTruthy();
@@ -217,33 +189,6 @@ describe('helpers map method for arrays', () => {
   });
 });
 
-describe('helpers mapObject method', () => {
-  const obj = {five: 5, ten: 10, fifty: 50, hundred: 100};
-  const predicate = (value) => {
-    return value / 5;
-  };
-  const objIdTest = {50: 5, 100: 10, 500: 50, 1000: 100};
-  const predicateIdTest = (value, id) => {
-    return id / value;
-  };
-
-  it('should map to an output array as per predicate', () => {
-    const resultObj = helpers.mapObject(obj, predicate);
-    expect(resultObj[0]).toBe(1);
-    expect(resultObj[1]).toBe(2);
-    expect(resultObj[2]).toBe(10);
-    expect(resultObj[3]).toBe(20);
-  });
-
-  it('should pass second parameter value to predicate', () => {
-    const resultObj = helpers.mapObject(objIdTest, predicateIdTest);
-    expect(resultObj[0]).toBe(10);
-    expect(resultObj[1]).toBe(10);
-    expect(resultObj[2]).toBe(10);
-    expect(resultObj[3]).toBe(10);
-  });
-});
-
 describe('helpers find method', () => {
   const arr = [123, 'abc', () => {}, undefined];
   const obj = 100;
@@ -254,11 +199,6 @@ describe('helpers find method', () => {
   it('should find first numeric value in array', () => {
     const resultObj = helpers.find(arr, predicate);
     expect(resultObj).toBe(123);
-  });
-
-  it('should execute predicate test if parameter passed is not an array but simple object', () => {
-    const resultObj = helpers.find(obj, predicate);
-    expect(resultObj).toBe(100);
   });
 
   it('should not alter original array', () => {
@@ -313,11 +253,6 @@ describe('helpers findIndex method', () => {
     expect(index).toBe(0);
   });
 
-  it('should execute predicate test if parameter passed is not an array but simple object', () => {
-    const resultObj = helpers.findIndex(obj, predicate);
-    expect(resultObj).toBe(0);
-  });
-
   it('should not alter original array', () => {
     helpers.findIndex(arr, predicate);
     expect(arr.length).toBe(4);
@@ -361,10 +296,6 @@ describe('helpers first method', () => {
     expect(helpers.first([undefined, 1, 2, 3])).toBe(undefined);
   });
 
-  it('should work for non-array value and return the value itself', () => {
-    expect(helpers.first('abc')).toBe('abc');
-  });
-
   it('should not break for empty array', () => {
     expect(helpers.first(undefined)).toBeFalsy();
     expect(helpers.first(null)).toBeFalsy();
@@ -384,10 +315,6 @@ describe('helpers last method', () => {
     expect(helpers.last(null)).toBeFalsy();
     expect(helpers.last([])).toBeFalsy();
   });
-
-  it('should work for non-array value and return the value itself', () => {
-    expect(helpers.last('abc')).toBe('abc');
-  });
 });
 
 describe('helpers size method', () => {
@@ -395,8 +322,8 @@ describe('helpers size method', () => {
     expect(helpers.size([1, 2, 3])).toBe(3);
   });
 
-  it('should return 0 for non-array argument', () => {
-    expect(helpers.size('abc')).toBe(1);
+  it('should return string length for strings', () => {
+    expect(helpers.size('abc')).toBe(3);
   });
 
   it('should not break for empty array', () => {
@@ -414,11 +341,6 @@ describe('helpers some method', () => {
 
   it('should return true is predicate is true for some element', () => {
     const result = helpers.some(arr, predicate);
-    expect(result).toBe(true);
-  });
-
-  it('should work well if argument is not array but simple object', () => {
-    const result = helpers.some(100, predicate);
     expect(result).toBe(true);
   });
 
@@ -464,14 +386,6 @@ describe('helpers union method', () => {
     helpers.union(arr1, arr2);
     expect(arr1.length).toBe(3);
     expect(arr2.length).toBe(3);
-  });
-
-  it('should work well if single object/array is passed', () => {
-    let resultArr = helpers.union(arr1);
-    expect(resultArr.length).toBe(3);
-    resultArr = helpers.union('abc');
-    expect(resultArr.length).toBe(1);
-    expect(resultArr[0]).toBe('abc');
   });
 
   it('should not break if array is undefined or null or has length 0', () => {

--- a/tests/__tests__/helpers-test.js
+++ b/tests/__tests__/helpers-test.js
@@ -121,6 +121,21 @@ describe('helpers isArrayLike method', () => {
   });
 });
 
+describe('helpers keys method', () => {
+  it('should return all keys in an object', () => {
+    const keys = helpers.keys({a: 1, b: 2, c: 3});
+    expect(keys.length).toBe(3);
+    expect(keys.indexOf('a')).toBeGreaterThan(-1);
+    expect(keys.indexOf('toString')).toBeLessThan(0);
+  });
+
+  it('should should not break for undefined/ null objects', () => {
+    expect(helpers.keys(undefined).length).toBe(0);
+    expect(helpers.keys(null).length).toBe(0);
+    expect(helpers.keys({}).length).toBe(0);
+  });
+});
+
 describe('helpers filter method', () => {
   const arr = [123, 'abc', () => {}, undefined];
   const predicate = (object) => {
@@ -202,7 +217,7 @@ describe('helpers map method for arrays', () => {
   });
 });
 
-describe('helpers map method for object', () => {
+describe('helpers mapObject method', () => {
   const obj = {five: 5, ten: 10, fifty: 50, hundred: 100};
   const predicate = (value) => {
     return value / 5;
@@ -213,7 +228,7 @@ describe('helpers map method for object', () => {
   };
 
   it('should map to an output array as per predicate', () => {
-    const resultObj = helpers.map(obj, predicate);
+    const resultObj = helpers.mapObject(obj, predicate);
     expect(resultObj[0]).toBe(1);
     expect(resultObj[1]).toBe(2);
     expect(resultObj[2]).toBe(10);
@@ -221,7 +236,7 @@ describe('helpers map method for object', () => {
   });
 
   it('should pass second parameter value to predicate', () => {
-    const resultObj = helpers.map(objIdTest, predicateIdTest);
+    const resultObj = helpers.mapObject(objIdTest, predicateIdTest);
     expect(resultObj[0]).toBe(10);
     expect(resultObj[1]).toBe(10);
     expect(resultObj[2]).toBe(10);
@@ -449,6 +464,14 @@ describe('helpers union method', () => {
     helpers.union(arr1, arr2);
     expect(arr1.length).toBe(3);
     expect(arr2.length).toBe(3);
+  });
+
+  it('should work well if single object/array is passed', () => {
+    let resultArr = helpers.union(arr1);
+    expect(resultArr.length).toBe(3);
+    resultArr = helpers.union('abc');
+    expect(resultArr.length).toBe(1);
+    expect(resultArr[0]).toBe('abc');
   });
 
   it('should not break if array is undefined or null or has length 0', () => {


### PR DESCRIPTION
Hey @nikgraf ,

This PR has changes in helper methods. If I pass a non-iterable object to any helper method expecting an array, it should treat it like array of single object. Its different from underscore which typically in such cases iterate over each field of object.

The reason for doing this change is select's typical case:
```
<select>
  <option>abc</option>
</select>
```

When select has single option react does not makes and array but single object which was breaking when we passed it to helper.filter. I did change in all methods as I wanted behavior to be consistent.

Changes look good now, can be merged.