### PR TITLE
Support React 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-component"
   ],
   "peerDependencies": {
-    "react": ">=0.13.0"
+    "react": ">=0.13.0 <0.15.0 || ^0.14.0-alpha"
   },
   "scripts": {
     "start": "babel --watch --source-maps-inline --optional='es7.classProperties' --out-dir='lib' src",
@@ -47,8 +47,18 @@
       "underscore"
     ],
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
-    "testFileExtensions": ["jsx", "js"],
-    "moduleFileExtensions": ["js", "json", "jsx"]
+    "testFileExtensions": [
+      "jsx",
+      "js"
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "jsx"
+    ]
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "exenv": "^1.2.0"
+  }
 }

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -7,7 +7,7 @@ import config from '../config/button';
 
 const buttonTypes = ['button', 'submit', 'reset'];
 
-// Enable React Touch Events    
+// Enable React Touch Events
 React.initializeTouchEvents && React.initializeTouchEvents(true);
 
 /**

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -7,6 +7,9 @@ import config from '../config/button';
 
 const buttonTypes = ['button', 'submit', 'reset'];
 
+// Enable React Touch Events    
+React.initializeTouchEvents && React.initializeTouchEvents(true);
+
 /**
  * Returns an object with properties that are relevant for the button element.
  *

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -7,10 +7,6 @@ import config from '../config/button';
 
 const buttonTypes = ['button', 'submit', 'reset'];
 
-// Enable React Touch Events
-React.initializeTouchEvents(true);
-
-
 /**
  * Returns an object with properties that are relevant for the button element.
  *

--- a/src/components/ComboBox.jsx
+++ b/src/components/ComboBox.jsx
@@ -4,7 +4,7 @@ import unionClassNames from '../utils/union-class-names';
 import {omit, extend, filterReactChildren, has, isEmpty, find, getArrayForReactChildren} from '../utils/helpers';
 import style from '../style/combo-box';
 
-// Enable React Touch Events    
+// Enable React Touch Events
 React.initializeTouchEvents && React.initializeTouchEvents(true);
 
 /**

--- a/src/components/ComboBox.jsx
+++ b/src/components/ComboBox.jsx
@@ -4,9 +4,6 @@ import unionClassNames from '../utils/union-class-names';
 import {omit, extend, filterReactChildren, has, isEmpty, find, getArrayForReactChildren} from '../utils/helpers';
 import style from '../style/combo-box';
 
-// Enable React Touch Events
-React.initializeTouchEvents(true);
-
 /**
  * Update hover style for the specified styleId.
  *

--- a/src/components/ComboBox.jsx
+++ b/src/components/ComboBox.jsx
@@ -4,6 +4,9 @@ import unionClassNames from '../utils/union-class-names';
 import {omit, extend, filterReactChildren, has, isEmpty, find, getArrayForReactChildren} from '../utils/helpers';
 import style from '../style/combo-box';
 
+// Enable React Touch Events    
+React.initializeTouchEvents && React.initializeTouchEvents(true);
+
 /**
  * Update hover style for the specified styleId.
  *

--- a/src/components/Rating.jsx
+++ b/src/components/Rating.jsx
@@ -1,15 +1,11 @@
 import React, {Component} from 'react';
-import { canUseDOM } from 'react/lib/ExecutionEnvironment';
+import { canUseDOM } from 'exenv';
 import {extend, omit, has} from '../utils/helpers';
 import style from '../style/rating.js';
 import {injectStyles, removeStyle} from '../utils/inject-style';
 import unionClassNames from '../utils/union-class-names';
 import config from '../config/rating';
 import {requestAnimationFrame, cancelAnimationFrame} from '../utils/animation-frame-management';
-
-// Enable React Touch Events
-React.initializeTouchEvents(true);
-
 
 /**
  * sanitize properties for the wrapping div.

--- a/src/components/Rating.jsx
+++ b/src/components/Rating.jsx
@@ -7,6 +7,9 @@ import unionClassNames from '../utils/union-class-names';
 import config from '../config/rating';
 import {requestAnimationFrame, cancelAnimationFrame} from '../utils/animation-frame-management';
 
+// Enable React Touch Events    
+React.initializeTouchEvents && React.initializeTouchEvents(true);
+
 /**
  * sanitize properties for the wrapping div.
  */

--- a/src/components/Rating.jsx
+++ b/src/components/Rating.jsx
@@ -7,7 +7,7 @@ import unionClassNames from '../utils/union-class-names';
 import config from '../config/rating';
 import {requestAnimationFrame, cancelAnimationFrame} from '../utils/animation-frame-management';
 
-// Enable React Touch Events    
+// Enable React Touch Events
 React.initializeTouchEvents && React.initializeTouchEvents(true);
 
 /**

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -1,14 +1,11 @@
 import React, {Component, PropTypes} from 'react';
 import {omit, extend, filter, filterReactChildren, find, first, flattenReactChildren, isEmpty, findIndex, last, uniqueId, has, some} from '../utils/helpers';
-import { canUseDOM } from 'react/lib/ExecutionEnvironment';
+import { canUseDOM } from 'exenv';
 import unionClassNames from '../utils/union-class-names';
 import {injectStyles, removeStyle} from '../utils/inject-style';
 import style from '../style/select';
 import config from '../config/select';
 import isComponentOfType from '../utils/is-component-of-type.js';
-
-// Enable React Touch Events
-React.initializeTouchEvents(true);
 
 /**
  * Returns true if the provided property is a Placeholder component from Belle.

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -7,6 +7,9 @@ import style from '../style/select';
 import config from '../config/select';
 import isComponentOfType from '../utils/is-component-of-type.js';
 
+// Enable React Touch Events    
+React.initializeTouchEvents && React.initializeTouchEvents(true);
+
 /**
  * Returns true if the provided property is a Placeholder component from Belle.
  */

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -7,7 +7,7 @@ import style from '../style/select';
 import config from '../config/select';
 import isComponentOfType from '../utils/is-component-of-type.js';
 
-// Enable React Touch Events    
+// Enable React Touch Events
 React.initializeTouchEvents && React.initializeTouchEvents(true);
 
 /**

--- a/src/components/Toggle.jsx
+++ b/src/components/Toggle.jsx
@@ -7,9 +7,6 @@ import isComponentOfType from '../utils/is-component-of-type.js';
 import {requestAnimationFrame, cancelAnimationFrame} from '../utils/animation-frame-management';
 import unionClassNames from '../utils/union-class-names';
 
-// Enable React Touch Events
-React.initializeTouchEvents(true);
-
 function sanitizeChildProps(properties) {
   return omit(properties, [
     'className',

--- a/src/components/Toggle.jsx
+++ b/src/components/Toggle.jsx
@@ -7,7 +7,7 @@ import isComponentOfType from '../utils/is-component-of-type.js';
 import {requestAnimationFrame, cancelAnimationFrame} from '../utils/animation-frame-management';
 import unionClassNames from '../utils/union-class-names';
 
-// Enable React Touch Events    
+// Enable React Touch Events
 React.initializeTouchEvents && React.initializeTouchEvents(true);
 
 function sanitizeChildProps(properties) {

--- a/src/components/Toggle.jsx
+++ b/src/components/Toggle.jsx
@@ -7,6 +7,9 @@ import isComponentOfType from '../utils/is-component-of-type.js';
 import {requestAnimationFrame, cancelAnimationFrame} from '../utils/animation-frame-management';
 import unionClassNames from '../utils/union-class-names';
 
+// Enable React Touch Events    
+React.initializeTouchEvents && React.initializeTouchEvents(true);
+
 function sanitizeChildProps(properties) {
   return omit(properties, [
     'className',

--- a/src/utils/animation-frame-management.js
+++ b/src/utils/animation-frame-management.js
@@ -1,6 +1,6 @@
 // Inspired by https://gist.github.com/paulirish/1579671
 
-import { canUseDOM } from 'react/lib/ExecutionEnvironment';
+import { canUseDOM } from 'exenv';
 
 export let requestAnimationFrame;
 export let cancelAnimationFrame;

--- a/src/utils/calculate-textarea-height.js
+++ b/src/utils/calculate-textarea-height.js
@@ -1,4 +1,4 @@
-import { canUseDOM } from 'react/lib/ExecutionEnvironment';
+import { canUseDOM } from 'exenv';
 
 let hiddenTextarea;
 const computedStyleCache = {};

--- a/src/utils/inject-style.js
+++ b/src/utils/inject-style.js
@@ -1,6 +1,6 @@
 import {flatten, mapObject} from '../utils/helpers';
 import CSSPropertyOperations from 'react/lib/CSSPropertyOperations';
-import { canUseDOM } from 'react/lib/ExecutionEnvironment';
+import { canUseDOM } from 'exenv';
 import animations from '../style/animations';
 
 let styleElement;


### PR DESCRIPTION
A few minor changes allow this to function with React 0.14 (which is in its third beta right now):

#### Replace `react/lib/ExecutionEnvironment` with `exenv` module

`ExecutionEnvironment` is not part of React's public API, and depending on it will break in 0.14, so I replaced it with a small dependency on [exenv](https://github.com/JedWatson/exenv), which was created for this exact purpose.

#### Conditionally call `initializeTouchEvents`

This function has been removed in 0.14, so I only call it if it is available.

I'm not entirely sure if we'll need to make any further changes to ensure touch support behaves the same way with 0.14.

### Summary

This PR shouldn't affect anyone currently using 0.13, but will allow for those using 0.14 to use Belle with their project. When 0.14-stable is released, we'll want to make sure touch events behave the same.

**Thanks for the awesome components! :beers:**