### PR TITLE
make sure normal styling does not influence height calculations

### DIFF
--- a/src/style/text-input.js
+++ b/src/style/text-input.js
@@ -19,6 +19,7 @@ const textInputStyle = {
     background: 'none',
     display: 'block',
     boxSizing: 'border-box',
+    minHeight: '0',
 
     /* animations */
     transition: 'border-bottom 0.2s',

--- a/src/utils/calculate-textarea-height.js
+++ b/src/utils/calculate-textarea-height.js
@@ -3,6 +3,8 @@ import { canUseDOM } from 'exenv';
 let hiddenTextarea;
 const computedStyleCache = {};
 const hiddenTextareaStyle = `
+  min-height:none !important;
+  max-height:none !important;
   height:0 !important;
   visibility:hidden !important;
   overflow:hidden !important;

--- a/src/utils/calculate-textarea-height.js
+++ b/src/utils/calculate-textarea-height.js
@@ -3,13 +3,13 @@ import { canUseDOM } from 'exenv';
 let hiddenTextarea;
 const computedStyleCache = {};
 const hiddenTextareaStyle = `
-  height:0;
-  visibility:hidden;
-  overflow:hidden;
-  position:absolute;
-  z-index:-1000;
-  top:0;
-  right:0
+  height:0 !important;
+  visibility:hidden !important;
+  overflow:hidden !important;
+  position:absolute !important;
+  z-index:-1000 !important;
+  top:0 !important;
+  right:0 !important
 `;
 
 const stylesToCopy = [
@@ -63,7 +63,7 @@ function calculateStyling(node) {
     );
 
     const sizingStyle = stylesToCopy
-      .map(styleName => `${styleName}:${computedStyle.getPropertyValue(styleName)}`)
+      .map(styleName => `${styleName}:${computedStyle.getPropertyValue(styleName)}  !important`)
       .join(';');
 
     // store the style, vertical padding size, vertical border size and


### PR DESCRIPTION
@jpuri you once mentioned a colleague messed with the height calculations by setting a min-height for all textareas. This would help to even prevent a global style influence on the calculations.