### PR TITLE
Datepicker improvements

### DIFF
--- a/docs/components/Configuration.js
+++ b/docs/components/Configuration.js
@@ -87,7 +87,7 @@ const styleStructure = `style = {
     // styling for month label on top of calendar
     monthLblStyle: { … },
     // styling for entire grid of week-header and weeks
-    weekGroupStyle: { … },
+    weekGridStyle: { … },
     // styling for week's day label
     dayLblStyle: { … },
     disabledDayLblStyle: { … },

--- a/docs/components/Configuration.js
+++ b/docs/components/Configuration.js
@@ -98,7 +98,7 @@ const styleStructure = `style = {
     readOnlyDayStyle: { … },
     activeDayStyle: { … },
     focusDayStyle: { … },
-    disabledHoverDayStyle: { … },
+    disabledFocusDayStyle: { … },
     todayStyle: { … },
     weekendStyle: { … },
     selectedDayStyle: { … },

--- a/docs/components/DatePickerDocumentation.js
+++ b/docs/components/DatePickerDocumentation.js
@@ -76,7 +76,7 @@ const advanceCodeExample5 = `
             disabled/>`;
 
 const advanceCodeExample6 = `
-<DatePicker onMonthYearChange={ this.onMonthYearChange }
+<DatePicker onMonthUpdate={ this.onMonthUpdate }
             month={ this.state.selectedMonth }
             year={ this.state.selectedYear }
             valueLink={ this.linkState('selectedDate') }/>
@@ -92,7 +92,7 @@ const advanceCodeExample6 = `
   <div><a onClick={ this.resetDate }>Reset Date</a></div>
 </div>
 
-onMonthYearChange(month, year) {
+onMonthUpdate(month, year) {
   this.setState({
     selectedMonth: month,
     selectedYear: year
@@ -355,7 +355,7 @@ export default React.createClass({
 
         <tr>
           <td style={ propertyNameStyle }>
-            onMonthYearChange
+            onMonthUpdate
           </td>
         </tr>
         <tr>
@@ -508,7 +508,7 @@ export default React.createClass({
         <span style={ {color: 'grey'} }> tabIndex, onFocus, onBlur, onKeyDown, onMouseDown, onMouseUp, onTouchStart,
         onTouchEnd, onPrevMonthNavMouseDown, onPrevMonthNavMouseUp, onPrevMonthNavTouchStart, onPrevMonthNavTouchEnd,
         onNextMonthNavMouseDown, onNextMonthNavMouseUp, onNextMonthNavTouchStart, onNextMonthNavTouchEnd, onDayMouseOver,
-        onDayMouseOut, onDayMouseDown, onDayMouseUp, onDayTouchStart, onDayTouchEnd, onUpdate, onMonthYearChange.
+        onDayMouseOut, onDayMouseDown, onDayMouseUp, onDayTouchStart, onDayTouchEnd, onUpdate, onMonthUpdate.
         </span><br />
       </p>
 
@@ -584,9 +584,9 @@ export default React.createClass({
 
       <Code value={ advanceCodeExample3 } style={ {marginTop: 40} } />
 
-      <h3>Controlled DatePicker component with onMonthYearChange callBack and reset option implemented:</h3>
+      <h3>Controlled DatePicker component with onMonthUpdate callBack and reset option implemented:</h3>
 
-      <DatePicker onMonthYearChange={ this.onMonthYearChange }
+      <DatePicker onMonthUpdate={ this.onMonthUpdate }
                   month={ this.state.selectedMonth }
                   year={ this.state.selectedYear }
                   valueLink={ this.linkState('selectedDate') }/>
@@ -642,7 +642,7 @@ export default React.createClass({
     );
   },
 
-  onMonthYearChange(month, year) {
+  onMonthUpdate(month, year) {
     this.setState({ selectedMonth: month, selectedYear: year });
   },
 

--- a/docs/components/DatePickerDocumentation.js
+++ b/docs/components/DatePickerDocumentation.js
@@ -493,7 +493,7 @@ export default React.createClass({
         disabledHoverStyle, navBarStyle, prevMonthNavStyle, hoverPrevMonthNavStyle, activePrevMonthNavStyle,
         nextMonthNavStyle, hoverNextMonthNavStyle, activeNextMonthNavStyle, monthLabelStyle, dayLabelStyle,
         disabledDayLabelStyle, weekendLabelStyle, dayStyle, disabledDayStyle, readOnlyDayStyle, activeDayStyle,
-        focusDayStyle, disabledHoverDayStyle, todayStyle, selectedDayStyle, otherMonthDayStyle, weekendStyle</span><br />
+        focusDayStyle, disabledFocusDayStyle, todayStyle, selectedDayStyle, otherMonthDayStyle, weekendStyle</span><br />
      </p>
 
       <h3>Internal HTML Structure</h3>

--- a/docs/components/DatePickerDocumentation.js
+++ b/docs/components/DatePickerDocumentation.js
@@ -40,10 +40,10 @@ const htmlStructure = `<div style={ style }>
 const advanceCodeExample1 = `
 <DatePicker defaultValue={ new Date(` + TODAY.getFullYear() + `, ` + TODAY.getMonth() + `, ` + 15 + `) }
             showOtherMonthDate={ false }
-            styleWeekend={ true }/>`;
+            styleWeekend />`;
 
 const advanceCodeExample2 = `
-<DatePicker readOnly={ true }
+<DatePicker readOnly
             renderDay={ this.renderDay }
             month={ 12 }/>
 
@@ -220,6 +220,42 @@ export default React.createClass({
             </p>
             <p>
               The date picker will be displayed for this year (though year can be changed by user).
+            </p>
+          </td>
+        </tr>
+
+        <tr>
+          <td style={ propertyNameStyle }>
+            min
+          </td>
+        </tr>
+        <tr>
+          <td style={ propertyDescriptionStyle }>
+            <p>
+              <i>Date</i>
+              <br />
+              optional
+            </p>
+            <p>
+              Sets the minimum date a user can select.
+            </p>
+          </td>
+        </tr>
+
+        <tr>
+          <td style={ propertyNameStyle }>
+            max
+          </td>
+        </tr>
+        <tr>
+          <td style={ propertyDescriptionStyle }>
+            <p>
+              <i>Date</i>
+              <br />
+              optional
+            </p>
+            <p>
+              Sets the maximum date a user can select.
             </p>
           </td>
         </tr>

--- a/docs/components/DatePickerDocumentation.js
+++ b/docs/components/DatePickerDocumentation.js
@@ -114,7 +114,7 @@ export default React.createClass({
       selectedMonth: TODAY.getMonth() + 1,
       selectedYear: TODAY.getFullYear(),
       selectedLocale: 'ar',
-      selectedDate: new Date(TODAY.getFullYear(), TODAY.getMonth(), 15)
+      selectedDate: new Date(TODAY.getFullYear(), TODAY.getMonth(), 15),
     };
   },
 
@@ -527,11 +527,15 @@ export default React.createClass({
         Adding support for a new locale is very easy, check <a href="#/configuration">Configuration</a>.</p>
 
       <Select valueLink={ this.linkState('selectedLocale') }
-            menuStyle={ { height: 160,
-            width: '25%',
-            overflow: 'scroll' } }
-            style={ { width: '25%',
-            marginBottom: 20}}>
+            menuStyle={{
+              height: 160,
+              width: '25%',
+              overflow: 'scroll',
+            }}
+            style={{
+              width: '25%',
+              marginBottom: 20,
+            }}>
         <Option value="ar">Arabic</Option>
         <Option value="fr">French</Option>
         <Option value="he">Hebrew</Option>
@@ -550,16 +554,19 @@ export default React.createClass({
                   month={ this.state.selectedMonth }
                   year={ this.state.selectedYear }
                   valueLink={ this.linkState('selectedDate') }/>
-      <div style={ {display: 'inline-block',
-                    width: 200,
-                    marginLeft: 20,
-                    marginTop: 10} }>
+      <div style={{
+        display: 'inline-block',
+        width: 200,
+        marginLeft: 20,
+        marginTop: 10,
+      }}>
       <div>Date: { this.state.selectedDate ? this.state.selectedDate.getMonth() + '/' + this.state.selectedDate.getDate() + '/' + this.state.selectedDate.getFullYear() : '-'}</div>
       <div>Month: {this.state.selectedMonth}</div>
       <div>Year: {this.state.selectedYear}</div>
       <div><a onClick={ this.resetDate }
-         style={{textDecoration: 'underline',
-                 cursor: 'pointer'
+         style={{
+           textDecoration: 'underline',
+           cursor: 'pointer',
          }}>Reset Date</a></div>
       </div>
 
@@ -593,6 +600,7 @@ export default React.createClass({
         </div>
       );
     }
+
     return (
       day.getDate()
     );
@@ -604,6 +612,6 @@ export default React.createClass({
 
   resetDate() {
     this.setState({ selectedDate: undefined });
-  }
+  },
 
 });

--- a/docs/components/DatePickerDocumentation.js
+++ b/docs/components/DatePickerDocumentation.js
@@ -272,7 +272,7 @@ export default React.createClass({
               optional
             </p>
             <p>
-              Date picker will be rendered according this locale
+              Date picker will be rendered according to this locale
               (By default it will be english calendar, check <a href="#/configuration">Configuration</a>).
             </p>
           </td>
@@ -291,7 +291,7 @@ export default React.createClass({
               optional (default: true)
             </p>
             <p>
-              This property can be used to show/ hide this display of other month dates in date picker.
+              This property can be used to show/ hide the display of other month dates in date picker.
               Even if other month dates are displayed in date picker they will be disabled.
             </p>
           </td>
@@ -485,31 +485,29 @@ export default React.createClass({
 
       <p>
         Properties for handling various events(focus, mouse events, touch events, change in selectedDate, month or year):
-        <span style={ {color: 'grey'} }> tabIndex, onFocus, onBlur, onKeyDown, onMouseDown, onMouseUp, onTouchStart,
-        onTouchEnd, onPrevMonthNavMouseDown, onPrevMonthNavMouseUp, onPrevMonthNavTouchStart, onPrevMonthNavTouchEnd,
-        onNextMonthNavMouseDown, onNextMonthNavMouseUp, onNextMonthNavTouchStart, onNextMonthNavTouchEnd, onDayMouseOver,
-        onDayMouseOut, onDayMouseDown, onDayMouseUp, onDayTouchStart, onDayTouchEnd, onUpdate, onMonthUpdate.
-        </span><br />
+        <span style={ {color: 'grey'} }>tabIndex, onFocus, onBlur, onKeyDown, onMouseDown, onMouseUp,
+        onTouchStart, onTouchEnd, onTouchCancel, onUpdate, onMonthUpdate.</span><br />
       </p>
 
       <p>
-        ... for adding attributes to date picker wrapper and days:
-        <span style={ {color: 'grey'} }> wrapperProps, dayProps</span><br />
+        ... for adding attributes to specific coponents inside date picker:
+        <span style={ {color: 'grey'} }>dayProps, navBarProps, prevMonthNavProps, prevMonthNavIconProps, nextMonthNavProps,
+        nextMonthNavIconProps, monthLabelProps, dayLabelProps, weekHeaderProps, weekGridProps.</span><br />
       </p>
 
       <p>
-        ... for adding classes to various parts of html structure of date picker:
-        <span style={ {color: 'grey'} }> wrapperClassName, navBarClassName, prevMonthNavClassName, nextMonthNavClassName,
-        monthLabelClassName, dayLabelClassName</span><br />
+        ... for adding class to date picker wrapper:
+        <span style={ {color: 'grey'} }>className.</span><br />
       </p>
 
       <p>
         ... for adding styling to various parts of html structure of date picker:
-        <span style={ {color: 'grey'} }> style, disabledStyle, readOnlyStyle, hoverStyle, activeStyle, focusStyle,
-        disabledHoverStyle, navBarStyle, prevMonthNavStyle, hoverPrevMonthNavStyle, activePrevMonthNavStyle,
-        nextMonthNavStyle, hoverNextMonthNavStyle, activeNextMonthNavStyle, monthLabelStyle, dayLabelStyle,
-        disabledDayLabelStyle, weekendLabelStyle, dayStyle, disabledDayStyle, readOnlyDayStyle, activeDayStyle,
-        focusDayStyle, disabledFocusDayStyle, todayStyle, selectedDayStyle, otherMonthDayStyle, weekendStyle</span><br />
+        <span style={ {color: 'grey'} }> style, disabledStyle, readOnlyStyle, hoverStyle, activeStyle, focusStyle, disabledHoverStyle, navBarStyle,
+        prevMonthNavStyle, prevMonthNavIconStyle, hoverPrevMonthNavStyle, activePrevMonthNavStyle, nextMonthNavStyle,
+        nextMonthNavIconStyle, hoverNextMonthNavStyle, activeNextMonthNavStyle, weekHeaderStyle, monthLabelStyle,
+        dayLabelStyle, disabledDayLabelStyle, weekendLabelStyle, dayStyle, disabledDayStyle, readOnlyDayStyle,
+        activeDayStyle, focusDayStyle, disabledFocusDayStyle, todayStyle, selectedDayStyle, otherMonthDayStyle,
+        weekendStyle.</span><br />
      </p>
 
       <h3>Internal HTML Structure</h3>

--- a/docs/components/DatePickerDocumentation.js
+++ b/docs/components/DatePickerDocumentation.js
@@ -520,7 +520,7 @@ export default React.createClass({
       <p>
         ... for adding classes to various parts of html structure of date picker:
         <span style={ {color: 'grey'} }> wrapperClassName, navBarClassName, prevMonthNavClassName, nextMonthNavClassName,
-        monthLabelClassName, dayLabelClassName, dayClassName</span><br />
+        monthLabelClassName, dayLabelClassName</span><br />
       </p>
 
       <p>

--- a/docs/components/DatePickerDocumentation.js
+++ b/docs/components/DatePickerDocumentation.js
@@ -39,8 +39,7 @@ const htmlStructure = `<div style={ style }>
 
 const advanceCodeExample1 = `
 <DatePicker defaultValue={ new Date(` + TODAY.getFullYear() + `, ` + TODAY.getMonth() + `, ` + 15 + `) }
-            showOtherMonthDate={ false }
-            styleWeekend />`;
+            showOtherMonthDate={ false } />`;
 
 const advanceCodeExample2 = `
 <DatePicker readOnly
@@ -300,25 +299,6 @@ export default React.createClass({
 
         <tr>
           <td style={ propertyNameStyle }>
-            styleWeekend
-          </td>
-        </tr>
-        <tr>
-          <td style={ propertyDescriptionStyle }>
-            <p>
-              <i>Boolean</i>
-              <br />
-              optional (default: false)
-            </p>
-            <p>
-              If this property is set to true weekend be styles distinctly.
-              Weekend for date picker will be provided in locale data and will be by default Sunday.
-            </p>
-          </td>
-        </tr>
-
-        <tr>
-          <td style={ propertyNameStyle }>
             renderDay
           </td>
         </tr>
@@ -546,8 +526,7 @@ export default React.createClass({
       <h3>DatePicker with other month days hidden but weekends styled differently:</h3>
 
       <DatePicker defaultValue={ new Date(TODAY.getFullYear(), TODAY.getMonth(), 15) }
-                  showOtherMonthDate={ false }
-                  styleWeekend/>
+                  showOtherMonthDate={ false } />
 
       <Code value={ advanceCodeExample1 } style={ {marginTop: 40} } />
 

--- a/examples/components/DatePickerPlayground.js
+++ b/examples/components/DatePickerPlayground.js
@@ -34,7 +34,7 @@ export default React.createClass({
         <Card>
           <h3>Default Calendar Example</h3>
           <div style={{ marginBottom: '20px' }}>
-            <DatePicker ref="calendar1" defaultValue={ selectedDate }/>
+            <DatePicker ref="calendar1"/>
           </div>
           <Button onClick={ this._resetValue }>Reset Date</Button>
 

--- a/examples/components/DatePickerPlayground.js
+++ b/examples/components/DatePickerPlayground.js
@@ -3,6 +3,19 @@ import {Card, DatePicker, Button} from 'belle';
 
 export default React.createClass({
 
+  _resetValue() {
+    this.refs.calendar1.resetValue();
+  },
+
+  _renderDay(day) {
+    const date = day.getDate();
+    return (
+      <div>
+        🎁{ date }
+      </div>
+    );
+  },
+
   render() {
     const selectedDate = new Date();
     selectedDate.setDate(selectedDate.getDate() + 5);
@@ -14,46 +27,39 @@ export default React.createClass({
 
         <Card>
           <h3>Default Calendar Example</h3>
-          <div style={ { 'marginBottom': '20px' } }>
+          <div style={{ marginBottom: '20px' }}>
             <DatePicker ref="calendar1" defaultValue={ selectedDate }/>
           </div>
           <Button onClick={ this._resetValue }>Reset Date</Button>
+
           <h3>Disabled Calendar Example</h3>
-          <div style={ { 'marginBottom': '20px' } }>
+            <div style={{ marginBottom: '20px' }}>
             <DatePicker showOtherMonthDate={ false } defaultValue={ selectedDate } disabled/>
           </div>
           <h3>Read-Only Calendar Example</h3>
-          <div style={ { 'marginBottom': '20px' } }>
-            <DatePicker styleWeekend={ true } defaultValue={ selectedDate } readOnly renderDay={ this.renderDay }/>
+          <div style={{ marginBottom: '20px' }}>
+            <DatePicker styleWeekend
+                        defaultValue={ selectedDate }
+                        readOnly
+                        renderDay={ this._renderDay }/>
           </div>
           <h3>Calendar in dutch french !!!</h3>
-          <div style={ { 'marginBottom': '20px' } }>
+          <div style={{ marginBottom: '20px' }}>
             <DatePicker defaultValue={ selectedDate } locale="fr"/>
           </div>
           <h3>Calendar in dutch arabic !!!</h3>
-          <div style={ { 'marginBottom': '20px' } }>
+          <div style={{ marginBottom: '20px' }}>
             <DatePicker defaultValue={ selectedDate } locale="ar"/>
           </div>
           <h3>Calendar in dutch hebrew !!!</h3>
-          <div style={ { 'marginBottom': '20px' } }>
-            <DatePicker styleWeekend={ true } defaultValue={ selectedDate } locale="he"/>
+          <div style={{ marginBottom: '20px' }}>
+            <DatePicker styleWeekend
+                        defaultValue={ selectedDate }
+                        locale="he"/>
           </div>
         </Card>
 
       </div>
     );
   },
-
-  _resetValue() {
-    this.refs.calendar1.resetValue();
-  },
-
-  renderDay(day) {
-    const date = day.getDate();
-    return (
-      <div>
-        🎁{ date }
-      </div>
-    );
-  }
 });

--- a/examples/components/DatePickerPlayground.js
+++ b/examples/components/DatePickerPlayground.js
@@ -10,10 +10,14 @@ export default React.createClass({
   _renderDay(day) {
     const date = day.getDate();
     return (
-      <div>
+      <div onMouseDown={::this._onMouseDown}>
         🎁{ date }
       </div>
     );
+  },
+
+  _onMouseDown(event) {
+    event.stopPropagation();
   },
 
   render() {

--- a/examples/components/DatePickerPlayground.js
+++ b/examples/components/DatePickerPlayground.js
@@ -47,13 +47,21 @@ export default React.createClass({
 
           <h3>Disabled Calendar Example</h3>
             <div style={{ marginBottom: '20px' }}>
-            <DatePicker showOtherMonthDate={ false } defaultValue={ selectedDate } disabled/>
+            <DatePicker defaultValue={ selectedDate } disabled/>
           </div>
-          <h3>Read-Only Calendar Example</h3>
+          <h3>Calendar without showing other months dates Example</h3>
+            <div style={{ marginBottom: '20px' }}>
+            <DatePicker showOtherMonthDate={ false } defaultValue={ selectedDate }/>
+          </div>
+          <h3>Read-Only + styleWeekend active Calendar Example</h3>
           <div style={{ marginBottom: '20px' }}>
             <DatePicker styleWeekend
                         defaultValue={ selectedDate }
-                        readOnly
+                        readOnly/>
+          </div>
+          <h3>Special renderDay</h3>
+          <div style={{ marginBottom: '20px' }}>
+            <DatePicker defaultValue={ selectedDate }
                         renderDay={ this._renderDay }/>
           </div>
           <h3>Calendar in dutch french !!!</h3>

--- a/examples/components/DatePickerPlayground.js
+++ b/examples/components/DatePickerPlayground.js
@@ -20,6 +20,12 @@ export default React.createClass({
     const selectedDate = new Date();
     selectedDate.setDate(selectedDate.getDate() + 5);
 
+    const minDate = new Date();
+    minDate.setDate(10);
+
+    const maxDate = new Date();
+    maxDate.setDate(20);
+
     return (
       <div>
 
@@ -31,6 +37,13 @@ export default React.createClass({
             <DatePicker ref="calendar1" defaultValue={ selectedDate }/>
           </div>
           <Button onClick={ this._resetValue }>Reset Date</Button>
+
+          <h3>DatePicker with min & max</h3>
+            <div style={{ marginBottom: '20px' }}>
+            <DatePicker defaultValue={ selectedDate }
+                        min={ minDate }
+                        max={ maxDate } />
+          </div>
 
           <h3>Disabled Calendar Example</h3>
             <div style={{ marginBottom: '20px' }}>

--- a/examples/components/DatePickerPlayground.js
+++ b/examples/components/DatePickerPlayground.js
@@ -53,10 +53,9 @@ export default React.createClass({
             <div style={{ marginBottom: '20px' }}>
             <DatePicker showOtherMonthDate={ false } defaultValue={ selectedDate }/>
           </div>
-          <h3>Read-Only + styleWeekend active Calendar Example</h3>
+          <h3>Read-Only active Calendar Example</h3>
           <div style={{ marginBottom: '20px' }}>
-            <DatePicker styleWeekend
-                        defaultValue={ selectedDate }
+            <DatePicker defaultValue={ selectedDate }
                         readOnly/>
           </div>
           <h3>Special renderDay</h3>
@@ -74,8 +73,7 @@ export default React.createClass({
           </div>
           <h3>Calendar in dutch hebrew !!!</h3>
           <div style={{ marginBottom: '20px' }}>
-            <DatePicker styleWeekend
-                        defaultValue={ selectedDate }
+            <DatePicker defaultValue={ selectedDate }
                         locale="he"/>
           </div>
         </Card>

--- a/src/__tests__/DatePicker-test.js
+++ b/src/__tests__/DatePicker-test.js
@@ -51,15 +51,17 @@ describe('DatePicker', () => {
   it('should select / deselect date when space key is pressed', () => {
     let dateSelected;
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="day_test" wrapperClassName="date_picker_wrapper" onUpdate={ (obj) => dateSelected = obj.value }/>
+      <DatePicker onUpdate={ (obj) => dateSelected = obj.value }/>
     );
 
     expect(datePicker.state.selectedDate).toBeUndefined();
+
     // const day = TestUtils.scryRenderedDOMComponentsWithClass(datePicker, 'day_test')[8];
     const dayPickerWrapper = TestUtils.scryRenderedDOMComponentsWithClass(datePicker, 'date_picker_wrapper')[0];
     TestUtils.Simulate.focus(dayPickerWrapper);
     TestUtils.Simulate.keyDown(dayPickerWrapper, {key: ' '});
     expect(datePicker.state.selectedDate).toBeGreaterThan(0);
+
     // expect(dateSelected.getDay()).toBeGreaterThan(0);
     TestUtils.Simulate.keyDown(dayPickerWrapper, {key: ' '});
     expect(datePicker.state.selectedDate).toBeUndefined();
@@ -68,7 +70,7 @@ describe('DatePicker', () => {
 
   it('should not change date when a day is focused and enter key is pressed if component is disabled or readOnly', () => {
     const disabledDatePicker = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="day_test" disabled/>
+      <DatePicker dayProps={{ className: 'day_test' }} disabled/>
     );
     expect(disabledDatePicker.state.selectedDate).toBeUndefined();
     let day = TestUtils.scryRenderedDOMComponentsWithClass(disabledDatePicker, 'day_test')[8];
@@ -77,7 +79,7 @@ describe('DatePicker', () => {
     expect(disabledDatePicker.state.selectedDate).toBeUndefined();
 
     const readOnlyDatePicker = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="day_test" readOnly/>
+      <DatePicker dayProps={{ className: 'day_test' }} readOnly/>
     );
     expect(readOnlyDatePicker.state.selectedDate).toBeUndefined();
     day = TestUtils.scryRenderedDOMComponentsWithClass(readOnlyDatePicker, 'day_test')[8];
@@ -88,7 +90,7 @@ describe('DatePicker', () => {
 
   it('should change focusedDateKey on mouse down', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="day_test"/>
+      <DatePicker dayProps={{ className: 'day_test' }}/>
     );
 
     expect(datePicker.state.focusedDateKey).toBeUndefined();
@@ -201,7 +203,7 @@ describe('DatePicker', () => {
 
   it.only('should show days in decreasing order if RTL for locale is true', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="date_picker_day" locale="ar"/>
+      <DatePicker dayProps={{ className: 'date_picker_day' }} locale="ar"/>
     );
 
     const datePickerDays = TestUtils.scryRenderedDOMComponentsWithClass(datePicker, 'date_picker_day');
@@ -212,7 +214,7 @@ describe('DatePicker', () => {
 
   it('should show friday as first day of week according to locale data in decreasing order', () => {
     const datePickerAr = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="date_picker_day" locale="ar"/>
+      <DatePicker dayProps={{ className: 'date_picker_day' }} locale="ar"/>
     );
 
     const datePickerDays = TestUtils.scryRenderedDOMComponentsWithClass(datePickerAr, 'date_picker_day');
@@ -222,7 +224,7 @@ describe('DatePicker', () => {
 
   it('should show friday as first day of week according to locale data', () => {
     const datePickerHe = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="date_picker_day" locale="he"/>
+      <DatePicker dayProps={{ className: 'date_picker_day' }} locale="he"/>
     );
     const datePickerDays = TestUtils.scryRenderedDOMComponentsWithClass(datePickerHe, 'date_picker_day');
     const firstDate = new Date(datePickerDays[0]._reactInternalInstance._currentElement.ref);
@@ -232,7 +234,7 @@ describe('DatePicker', () => {
   it('should change selectedDate when a day receives mouseDown with button 0', () => {
     let dateSelected;
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="day_test" onUpdate={ (obj) => dateSelected = obj.value }/>
+      <DatePicker dayProps={{ className: 'day_test' }} onUpdate={ (obj) => dateSelected = obj.value }/>
     );
 
     expect(datePicker.state.selectedDate).toBeUndefined();
@@ -249,7 +251,7 @@ describe('DatePicker', () => {
 
   it('should not change selectedDate in state if component uses value property', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="day_test" value={ undefined }/>
+      <DatePicker dayProps={{ className: 'day_test' }} value={ undefined }/>
     );
 
     expect(datePicker.state.selectedDate).toBeUndefined();
@@ -259,18 +261,17 @@ describe('DatePicker', () => {
     expect(datePicker.state.selectedDate).toBeUndefined();
   });
 
-
   it('should not change selectedDate in state if component uses valueLink property', () => {
     const compSelectedDate = new Date();
     const valueLink = {
       value: compSelectedDate,
       requestChange: () => {
         // compSelectedDate = newValue;
-      }
+      },
     };
 
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="day_test" valueLink={ valueLink }/>
+      <DatePicker dayProps={{ className: 'day_test' }} valueLink={ valueLink }/>
     );
 
     expect(datePicker.state.selectedDate).toBe(compSelectedDate);
@@ -322,7 +323,7 @@ describe('DatePicker', () => {
       value: compSelectedDate,
       requestChange: (newValue) => {
         compSelectedDate = newValue;
-      }
+      },
     };
     expect(datePicker.state.selectedDate).toBeUndefined();
     datePicker.componentWillReceiveProps({valueLink: valueLink});
@@ -341,7 +342,7 @@ describe('DatePicker', () => {
 
   it('should set isFocused to true when wrapper receives focus and to false on blur', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker wrapperClassName="wrapper_test"/>
+      <DatePicker className="wrapper_test"/>
     );
     const wrapper = TestUtils.findRenderedDOMComponentWithClass(datePicker, 'wrapper_test');
     TestUtils.Simulate.focus(wrapper);
@@ -352,7 +353,7 @@ describe('DatePicker', () => {
 
   it('should not set isFocused to true when wrapper receives focus btu component is disabled', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker wrapperClassName="wrapper_test" disabled/>
+      <DatePicker className="wrapper_test" disabled/>
     );
     const wrapper = TestUtils.findRenderedDOMComponentWithClass(datePicker, 'wrapper_test');
     TestUtils.Simulate.focus(wrapper);
@@ -361,7 +362,7 @@ describe('DatePicker', () => {
 
   it('should not set isFocused to true when wrapper receives focus but is active', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker wrapperClassName="wrapper_test"/>
+      <DatePicker className="wrapper_test"/>
     );
     const wrapper = TestUtils.findRenderedDOMComponentWithClass(datePicker, 'wrapper_test');
     TestUtils.Simulate.mouseDown(wrapper, {button: 0});
@@ -372,7 +373,7 @@ describe('DatePicker', () => {
 
   it('should not set isActive to true when touch starts and reset when touch ends', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker wrapperClassName="wrapper_test"/>
+      <DatePicker className="wrapper_test"/>
     );
     const wrapper = TestUtils.findRenderedDOMComponentWithClass(datePicker, 'wrapper_test');
     TestUtils.Simulate.touchStart(wrapper, {touches: {length: 1}});
@@ -383,7 +384,7 @@ describe('DatePicker', () => {
 
   it('should set isWrapperHovered on mouse over for all components including disabled and readOnly', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker wrapperClassName="wrapper_test"/>
+      <DatePicker className="wrapper_test"/>
     );
     const wrapper = TestUtils.findRenderedDOMComponentWithClass(datePicker, 'wrapper_test');
     TestUtils.Simulate.mouseOver(wrapper);
@@ -392,7 +393,7 @@ describe('DatePicker', () => {
     expect(datePicker.state.isWrapperHovered).toBeFalsy();
 
     const disabledDatePicker = TestUtils.renderIntoDocument(
-      <DatePicker disabled dayClassName="day_test" wrapperClassName="wrapper_test"/>
+      <DatePicker disabled dayProps={{ className: 'day_test' }} className="wrapper_test"/>
     );
     const disabledWrapper = TestUtils.findRenderedDOMComponentWithClass(disabledDatePicker, 'wrapper_test');
     TestUtils.Simulate.mouseOver(disabledWrapper);
@@ -401,7 +402,7 @@ describe('DatePicker', () => {
     expect(disabledDatePicker.state.isWrapperHovered).toBeFalsy();
 
     const readOnlyDatePicker = TestUtils.renderIntoDocument(
-      <DatePicker readOnly dayClassName="day_test" wrapperClassName="wrapper_test"/>
+      <DatePicker readOnly dayProps={{ className: 'day_test' }} className="wrapper_test"/>
     );
     const readOnlyWrapper = TestUtils.findRenderedDOMComponentWithClass(readOnlyDatePicker, 'wrapper_test');
     TestUtils.Simulate.mouseOver(readOnlyWrapper);
@@ -412,7 +413,7 @@ describe('DatePicker', () => {
 
   it('should not focus day on disabled component', () => {
     const disabledDatePicker = TestUtils.renderIntoDocument(
-      <DatePicker disabled dayClassName="day_test"/>
+      <DatePicker disabled dayProps={{ className: 'day_test' }}/>
     );
     expect(disabledDatePicker.state.focusedDateKey).toBeUndefined();
     const day = TestUtils.scryRenderedDOMComponentsWithClass(disabledDatePicker, 'day_test')[8];
@@ -422,7 +423,7 @@ describe('DatePicker', () => {
 
   it('should focus readOnly component', () => {
     const readOnlyDatePicker = TestUtils.renderIntoDocument(
-      <DatePicker wrapperClassName="date_picker" readOnly dayClassName="day_test"/>
+      <DatePicker wrapperClassName="date_picker" readOnly dayProps={{ className: 'day_test' }}/>
     );
     expect(readOnlyDatePicker.state.focusedDateKey).toBeUndefined();
     const datePicker = TestUtils.scryRenderedDOMComponentsWithClass(readOnlyDatePicker, 'date_picker')[0];
@@ -452,7 +453,7 @@ describe('DatePicker', () => {
 
   it('should set activeDay when touch starts on a day and reset when touch ends', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker dayClassName="day_test"/>
+      <DatePicker dayProps={{ className: 'day_test' }}/>
     );
     const day = TestUtils.scryRenderedDOMComponentsWithClass(datePicker, 'day_test')[8];
     expect(datePicker.state.activeDay).toBeFalsy();
@@ -464,7 +465,7 @@ describe('DatePicker', () => {
 
   it('should apply hover styles to wrapper when mouse is over', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker wrapperClassName="wrapper_test" hoverStyle={ {backgroundColor: 'red'} }/>
+      <DatePicker className="wrapper_test" hoverStyle={ {backgroundColor: 'red'} }/>
     );
     const wrapper = TestUtils.findRenderedDOMComponentWithClass(datePicker, 'wrapper_test');
     TestUtils.Simulate.mouseOver(wrapper);
@@ -476,7 +477,7 @@ describe('DatePicker', () => {
 
   it('should apply activeDayStyle to day when touchStart but immediately after touchEnd should apply selectedDayStyle', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker activeDayStyle={ {color: 'blue'} } selectedDayStyle={ {color: 'red'} } dayClassName="day_test"/>
+      <DatePicker activeDayStyle={ {color: 'blue'} } selectedDayStyle={ {color: 'red'} } dayProps={{ className: 'day_test' }}/>
     );
     expect(datePicker.state.selectedDate).toBeUndefined();
     const day = TestUtils.scryRenderedDOMComponentsWithClass(datePicker, 'day_test')[8];
@@ -501,7 +502,7 @@ describe('DatePicker', () => {
 
   it('should apply focusDayStyles for mouseDown by on day', () => {
     const datePicker = TestUtils.renderIntoDocument(
-      <DatePicker focusDayStyle={ {fontSize: '5px'} } activeDayStyle={ {backgroundColor: 'blue'} } dayClassName="day_test"/>
+      <DatePicker focusDayStyle={ {fontSize: '5px'} } activeDayStyle={ {backgroundColor: 'blue'} } dayProps={{ className: 'day_test' }}/>
     );
     const day = TestUtils.scryRenderedDOMComponentsWithClass(datePicker, 'day_test')[8];
     TestUtils.Simulate.mouseDown(day, {button: 0});

--- a/src/__tests__/DatePicker-test.js
+++ b/src/__tests__/DatePicker-test.js
@@ -26,7 +26,6 @@ describe('DatePicker', () => {
     expect(datePicker.props.disabled).toBe(false);
     expect(datePicker.props.readOnly).toBe(false);
     expect(datePicker.props.showOtherMonthDate).toBe(true);
-    expect(datePicker.props.styleWeekend).toBe(false);
   });
 
   it('should have undefined date value if value is not passed in props', () => {

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -982,7 +982,6 @@ export default class DatePicker extends Component {
    * 2. If active apply activeStyles
    */
   _renderNavBar() {
-    console.log('*****', this.localeData.monthNames[this.state.month]);
     const navBarStyle = {
       ...defaultStyle.navBarStyle,
       ...this.props.navBarStyle,

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -195,7 +195,7 @@ export default class DatePicker extends Component {
 
     // callbacks for change of values
     onUpdate: PropTypes.func,
-    onMonthYearChange: PropTypes.func,
+    onMonthUpdate: PropTypes.func,
 
     // props for wrapper and day
     wrapperProps: PropTypes.object,
@@ -749,7 +749,7 @@ export default class DatePicker extends Component {
   }
 
   /**
-   * The function will decrease current month in state. It will also call props.onMonthYearChange.
+   * The function will decrease current month in state. It will also call props.onMonthUpdate.
    */
   _decreaseMonthYear() {
     let newMonth;
@@ -768,13 +768,13 @@ export default class DatePicker extends Component {
       focusedDateKey: undefined,
       lastHoveredDay: undefined,
     });
-    if (this.props.onMonthYearChange) {
-      this.props.onMonthYearChange(newMonth + 1, newYear);
+    if (this.props.onMonthUpdate) {
+      this.props.onMonthUpdate(newMonth + 1, newYear);
     }
   }
 
   /**
-   * The function will increase current month in state. It will also call props.onMonthYearChange.
+   * The function will increase current month in state. It will also call props.onMonthUpdate.
    */
   _increaseMonthYear() {
     let newMonth;
@@ -793,8 +793,8 @@ export default class DatePicker extends Component {
       focusedDateKey: undefined,
       lastHoveredDay: undefined,
     });
-    if (this.props.onMonthYearChange) {
-      this.props.onMonthYearChange(newMonth + 1, newYear);
+    if (this.props.onMonthUpdate) {
+      this.props.onMonthUpdate(newMonth + 1, newYear);
     }
   }
 

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -717,7 +717,7 @@ export default class DatePicker extends Component {
 
     const nextFocusedDate = new Date(this.state.focusedDateKey);
     nextFocusedDate.setDate(nextFocusedDate.getDate() + days);
-    const nextFocusedDateKey = `${nextFocusedDate.getFullYear()}-${nextFocusedDate.getMonth() + 1}-${nextFocusedDate.getDate()}`;
+    const nextFocusedDateKey = convertDateToDateKey(nextFocusedDate);
     const nextMonth = nextFocusedDate.getMonth();
 
     if (nextMonth !== currentMonth) {
@@ -933,7 +933,7 @@ export default class DatePicker extends Component {
     const month = currentDate.getMonth();
     const year = currentDate.getFullYear();
     const isOtherMonth = currentDate.getMonth() !== this.state.month;
-    const dateKey = `${currentDate.getFullYear()}-${currentDate.getMonth() + 1}-${day}`;
+    const dateKey = convertDateToDateKey(currentDate);
 
     let ariaCurrent = '';
     let ariaSelected = false;

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -81,6 +81,56 @@ function sanitizeDayProps(properties) {
   ]);
 }
 
+function sanitizeNavBarProps(properties) {
+  return omit(properties, [
+    'style',
+  ]);
+}
+
+function sanitizePrevMonthNavProps(properties) {
+  return omit(properties, [
+    'className',
+    'onClick',
+    'style',
+  ]);
+}
+
+function sanitizePrevMonthNavIconProps(properties) {
+  return omit(properties, [
+    'style',
+  ]);
+}
+
+function sanitizeNextMonthNavProps(properties) {
+  return omit(properties, [
+    'className',
+    'onClick',
+    'style',
+  ]);
+}
+
+function sanitizeNextMonthNavIconProps(properties) {
+  return omit(properties, [
+    'style',
+  ]);
+}
+
+function sanitizeMonthLabelProps(properties) {
+  return omit(properties, [
+    'id',
+    'role',
+    'style',
+  ]);
+}
+
+function sanitizeDayLabelProps(properties) {
+  return omit(properties, [
+    'key',
+    'role',
+    'style',
+  ]);
+}
+
 /**
  * Injects pseudo classes for styles into the DOM.
  */
@@ -172,6 +222,14 @@ export default class DatePicker extends Component {
     this.dayProps = sanitizeDayProps(properties.dayProps);
     this.disabledDayProps = sanitizeDisabledDayProps(properties.dayProps);
     this.emptyDayProps = sanitizeEmptyDayProps(properties.dayProps);
+    this.navBarProps = sanitizeNavBarProps(properties.navBarProps);
+    this.prevMonthNavProps = sanitizePrevMonthNavProps(properties.prevMonthNavProps);
+    this.prevMonthNavIconProps = sanitizePrevMonthNavIconProps(properties.prevMonthNavIconProps);
+    this.nextMonthNavProps = sanitizeNextMonthNavProps(properties.nextMonthNavProps);
+    this.nextMonthNavIconProps = sanitizeNextMonthNavIconProps(properties.nextMonthNavIconProps);
+    this.monthLabelProps = sanitizeMonthLabelProps(properties.monthLabelProps);
+    this.dayLabelProps = sanitizeDayLabelProps(properties.dayLabelProps);
+
     this.preventFocusStyleForTouchAndClick = has(properties, 'preventFocusStyleForTouchAndClick') ? properties.preventFocusStyleForTouchAndClick : config.preventFocusStyleForTouchAndClick;
   }
 
@@ -215,18 +273,18 @@ export default class DatePicker extends Component {
     onUpdate: PropTypes.func,
     onMonthUpdate: PropTypes.func,
 
-    // props for wrapper and day
+    // props
     dayProps: PropTypes.object,
+    navBarProps: PropTypes.object,
+    prevMonthNavProps: PropTypes.object,
+    prevMonthNavIconProps: PropTypes.object,
+    nextMonthNavProps: PropTypes.object,
+    nextMonthNavIconProps: PropTypes.object,
+    monthLabelProps: PropTypes.object,
+    dayLabelProps: PropTypes.object,
 
     // ClassNames
     className: PropTypes.string,
-    navBarClassName: PropTypes.string,
-    prevMonthNavClassName: PropTypes.string,
-    prevMonthNavIconClassName: PropTypes.string,
-    nextMonthNavClassName: PropTypes.string,
-    nextMonthNavIconClassName: PropTypes.string,
-    monthLabelClassName: PropTypes.string,
-    dayLabelClassName: PropTypes.string,
 
     // wrapper styles
     style: PropTypes.object,
@@ -318,6 +376,14 @@ export default class DatePicker extends Component {
     this.dayProps = sanitizeDayProps(properties.dayProps);
     this.disabledDayProps = sanitizeDisabledDayProps(properties.dayProps);
     this.emptyDayProps = sanitizeEmptyDayProps(properties.dayProps);
+    this.navBarProps = sanitizeNavBarProps(properties.navBarProps);
+    this.prevMonthNavProps = sanitizePrevMonthNavProps(properties.prevMonthNavProps);
+    this.prevMonthNavIconProps = sanitizePrevMonthNavIconProps(properties.prevMonthNavIconProps);
+    this.nextMonthNavProps = sanitizeNextMonthNavProps(properties.nextMonthNavProps);
+    this.nextMonthNavIconProps = sanitizeNextMonthNavIconProps(properties.nextMonthNavIconProps);
+    this.monthLabelProps = sanitizeMonthLabelProps(properties.monthLabelProps);
+    this.dayLabelProps = sanitizeDayLabelProps(properties.dayLabelProps);
+
     this.preventFocusStyleForTouchAndClick = has(properties, 'preventFocusStyleForTouchAndClick') ? properties.preventFocusStyleForTouchAndClick : config.preventFocusStyleForTouchAndClick;
 
     removeAllStyles(Object.keys(this.pseudoStyleIds));
@@ -820,6 +886,20 @@ export default class DatePicker extends Component {
              this.props.max && date > this.props.max);
   }
 
+  _onClickPrevMonth() {
+    this._decreaseMonthYear();
+    if (this.props.prevMonthNavProps && this.props.prevMonthNavProps.onClick) {
+      this.props.prevMonthNavProps.onClick(event);
+    }
+  }
+
+  _onClickNextMonth() {
+    this._increaseMonthYear();
+    if (this.props.nextMonthNavProps && this.props.nextMonthNavProps.onClick) {
+      this.props.nextMonthNavProps.onClick(event);
+    }
+  }
+
   _renderPrevMonthNav() {
     const prevMonthNavStyle = {
       ...defaultStyle.prevMonthNavStyle,
@@ -831,12 +911,18 @@ export default class DatePicker extends Component {
       ...this.props.prevMonthNavIconStyle,
     };
 
+    let className = this.pseudoStyleIds.prevMonthNavStyleId;
+    if (this.props.prevMonthNavProps) {
+      className = unionClassNames(this.props.prevMonthNavProps.className, className);
+    }
+
     return (
-      <ActionArea onClick={ ::this._decreaseMonthYear }
+      <ActionArea onClick={ ::this._onClickPrevMonth }
                   style={ prevMonthNavStyle }
-                  className={ unionClassNames(this.props.prevMonthNavClassName, this.pseudoStyleIds.prevMonthNavStyleId) }>
+                  className={ className }
+                  { ...this.prevMonthNavProps }>
         <div style={ prevMonthNavIconStyle }
-             className={this.props.prevMonthNavIconClassName}/>
+             { ...this.prevMonthNavIconProps }/>
       </ActionArea>
     );
   }
@@ -852,12 +938,18 @@ export default class DatePicker extends Component {
       ...this.props.nextMonthNavIconStyle,
     };
 
+    let className = this.pseudoStyleIds.nextMonthNavStyleId;
+    if (this.props.prevMonthNavProps) {
+      className = unionClassNames(this.props.prevMonthNavProps.className, className);
+    }
+
     return (
-      <ActionArea onClick={ ::this._increaseMonthYear }
+      <ActionArea onClick={ ::this._onClickNextMonth }
                   style= { nextMonthNavStyle }
-                  className={ unionClassNames(this.props.nextMonthNavClassName, this.pseudoStyleIds.nextMonthNavStyleId) }>
+                  className={ className }
+                  { ...this.nextMonthNavProps }>
         <div style={ nextMonthNavIconStyle }
-             className={this.props.nextMonthNavIconClassName}/>
+             { ...this.nextMonthNavIconProps } />
       </ActionArea>
     );
   }
@@ -880,15 +972,15 @@ export default class DatePicker extends Component {
 
     return (
       <div style={ navBarStyle }
-           className={ this.props.navBarClassName }>
+           { ...this.navBarProps }>
         { this._renderPrevMonthNav() }
         <span style={ monthLabelStyle }
-              className={ this.props.monthLabelClassName }
               role="heading"
               /*
                 This label has an id as suggested in http://www.w3.org/TR/wai-aria-practices/#datepicker
               */
-              id={ `${this.state.year}-${this.state.month}` }>
+              id={ `${this.state.year}-${this.state.month}` }
+              { ...this.monthLabelProps }>
           { `${this.localeData.monthNames[this.state.month]} ${this.state.year}` }
         </span>
         { this._renderNextMonthNav() }
@@ -936,8 +1028,8 @@ export default class DatePicker extends Component {
             return (
               <span key={ 'dayAbbr-' + index }
                     style={ index === weekendIndex ? weekendLabelStyle : dayLabelStyle }
-                    className={ this.props.dayLabelClassName }
-                    role="columnheader">
+                    role="columnheader"
+                    { ...this.dayLabelProps }>
                   { dayAbbr }
                 </span>
             );

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -39,9 +39,32 @@ function sanitizeWrapperProps(properties) {
 /**
  * Returns an object with properties that are relevant for day span.
  */
+function sanitizeEmptyDayProps(properties) {
+  return omit(properties, [
+    'key',
+    'ref',
+    'style',
+  ]);
+}
+
+/**
+ * Returns an object with properties that are relevant for day span.
+ */
+function sanitizeDisabledDayProps(properties) {
+  return omit(properties, [
+    'key',
+    'ref',
+    'onMouseOver',
+    'onMouseOut',
+    'style',
+  ]);
+}
+
+/**
+ * Returns an object with properties that are relevant for day span.
+ */
 function sanitizeDayProps(properties) {
   return omit(properties, [
-    'tabIndex',
     'key',
     'ref',
     'onMouseDown',
@@ -51,8 +74,10 @@ function sanitizeDayProps(properties) {
     'onTouchStart',
     'onTouchEnd',
     'onTouchCancel',
+    'aria-current',
+    'aria-selected',
     'style',
-    'className',
+    'role',
   ]);
 }
 
@@ -145,6 +170,8 @@ export default class DatePicker extends Component {
     this.localeData = getLocaleData(properties.locale);
     this.wrapperProps = sanitizeWrapperProps(properties);
     this.dayProps = sanitizeDayProps(properties.dayProps);
+    this.disabledDayProps = sanitizeDisabledDayProps(properties.dayProps);
+    this.emptyDayProps = sanitizeEmptyDayProps(properties.dayProps);
     this.preventFocusStyleForTouchAndClick = has(properties, 'preventFocusStyleForTouchAndClick') ? properties.preventFocusStyleForTouchAndClick : config.preventFocusStyleForTouchAndClick;
   }
 
@@ -292,6 +319,8 @@ export default class DatePicker extends Component {
     this.localeData = getLocaleData(properties.locale);
     this.wrapperProps = sanitizeWrapperProps(properties);
     this.dayProps = sanitizeDayProps(properties.dayProps);
+    this.disabledDayProps = sanitizeDisabledDayProps(properties.dayProps);
+    this.emptyDayProps = sanitizeEmptyDayProps(properties.dayProps);
     this.preventFocusStyleForTouchAndClick = has(properties, 'preventFocusStyleForTouchAndClick') ? properties.preventFocusStyleForTouchAndClick : config.preventFocusStyleForTouchAndClick;
 
     removeAllStyles(Object.keys(this.pseudoStyleIds));
@@ -1034,8 +1063,7 @@ export default class DatePicker extends Component {
         <span key={ 'day-' + index }
               ref={ dateKey }
               style={ dayStyle }
-              className={ this.props.dayClassName }
-              {...this.dayProps}>
+              {...this.emptyDayProps}>
         </span>
       );
     }
@@ -1045,10 +1073,9 @@ export default class DatePicker extends Component {
         <span key={ 'day-' + index }
               ref={ dateKey }
               style={ dayStyle }
-              className={ this.props.dayClassName }
               onMouseOver={ this._onDayMouseOver.bind(this, dateKey) }
               onMouseOut={ this._onDayMouseOut.bind(this, dateKey) }
-              {...this.dayProps}>
+              {...this.disabledDayProps}>
           { renderedDay }
         </span>
       );
@@ -1067,7 +1094,6 @@ export default class DatePicker extends Component {
             aria-current={ ariaCurrent }
             aria-selected={ ariaSelected }
             style={ dayStyle }
-            className={ this.props.dayClassName }
             role="gridcell"
             {...this.dayProps}>
         { renderedDay }

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -131,6 +131,19 @@ function sanitizeDayLabelProps(properties) {
   ]);
 }
 
+function sanitizeWeekHeaderProps(properties) {
+  return omit(properties, [
+    'style',
+  ]);
+}
+
+function sanitizeWeekGridProps(properties) {
+  return omit(properties, [
+    'role',
+    'style',
+  ]);
+}
+
 /**
  * Injects pseudo classes for styles into the DOM.
  */
@@ -229,6 +242,8 @@ export default class DatePicker extends Component {
     this.nextMonthNavIconProps = sanitizeNextMonthNavIconProps(properties.nextMonthNavIconProps);
     this.monthLabelProps = sanitizeMonthLabelProps(properties.monthLabelProps);
     this.dayLabelProps = sanitizeDayLabelProps(properties.dayLabelProps);
+    this.weekHeaderProps = sanitizeWeekHeaderProps(properties.weekHeaderProps);
+    this.weekGridProps = sanitizeWeekGridProps(properties.weekGridProps);
 
     this.preventFocusStyleForTouchAndClick = has(properties, 'preventFocusStyleForTouchAndClick') ? properties.preventFocusStyleForTouchAndClick : config.preventFocusStyleForTouchAndClick;
   }
@@ -282,6 +297,8 @@ export default class DatePicker extends Component {
     nextMonthNavIconProps: PropTypes.object,
     monthLabelProps: PropTypes.object,
     dayLabelProps: PropTypes.object,
+    weekHeaderProps: PropTypes.object,
+    weekGridProps: PropTypes.object,
 
     // ClassNames
     className: PropTypes.string,
@@ -383,6 +400,8 @@ export default class DatePicker extends Component {
     this.nextMonthNavIconProps = sanitizeNextMonthNavIconProps(properties.nextMonthNavIconProps);
     this.monthLabelProps = sanitizeMonthLabelProps(properties.monthLabelProps);
     this.dayLabelProps = sanitizeDayLabelProps(properties.dayLabelProps);
+    this.weekHeaderProps = sanitizeWeekHeaderProps(properties.weekHeaderProps);
+    this.weekGridProps = sanitizeWeekGridProps(properties.weekGridProps);
 
     this.preventFocusStyleForTouchAndClick = has(properties, 'preventFocusStyleForTouchAndClick') ? properties.preventFocusStyleForTouchAndClick : config.preventFocusStyleForTouchAndClick;
 
@@ -1022,7 +1041,8 @@ export default class DatePicker extends Component {
     weekendIndex = this.localeData.isRTL ? 6 - weekendIndex : weekendIndex;
 
     return (
-      <div style={ weekHeaderStyle }>
+      <div style={ weekHeaderStyle }
+           { ...this.weekHeaderProps }>
         {
           map(dayNames, (dayAbbr, index) => {
             return (
@@ -1030,8 +1050,8 @@ export default class DatePicker extends Component {
                     style={ index === weekendIndex ? weekendLabelStyle : dayLabelStyle }
                     role="columnheader"
                     { ...this.dayLabelProps }>
-                  { dayAbbr }
-                </span>
+                { dayAbbr }
+              </span>
             );
           })
         }
@@ -1266,7 +1286,9 @@ export default class DatePicker extends Component {
            }
            {...this.wrapperProps} >
         { this._renderNavBar() }
-        <div role="grid" style={ defaultStyle.weekGroupStyle}>
+        <div role="grid"
+             style={ defaultStyle.weekGridStyle }
+             { ...this.weekGridProps }>
           { this._renderWeekHeader() }
           {
             map(weekArray, (week) => {

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -1039,6 +1039,7 @@ export default class DatePicker extends Component {
         </span>
       );
     }
+
     return (
       <span key={ 'day-' + index }
             ref={ dateKey }

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -194,7 +194,6 @@ export default class DatePicker extends Component {
     month: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
     year: PropTypes.number,
     showOtherMonthDate: PropTypes.bool,
-    styleWeekend: PropTypes.bool,
     renderDay: PropTypes.func,
     tabIndex: PropTypes.number,
     'aria-label': PropTypes.string,
@@ -228,7 +227,6 @@ export default class DatePicker extends Component {
     nextMonthNavIconClassName: PropTypes.string,
     monthLabelClassName: PropTypes.string,
     dayLabelClassName: PropTypes.string,
-    dayClassName: PropTypes.string,
 
     // wrapper styles
     style: PropTypes.object,
@@ -283,7 +281,6 @@ export default class DatePicker extends Component {
     disabled: false,
     readOnly: false,
     showOtherMonthDate: true,
-    styleWeekend: false,
   };
 
   /**
@@ -938,7 +935,7 @@ export default class DatePicker extends Component {
           map(dayNames, (dayAbbr, index) => {
             return (
               <span key={ 'dayAbbr-' + index }
-                    style={ (this.props.styleWeekend && index === weekendIndex) ? weekendLabelStyle : dayLabelStyle }
+                    style={ index === weekendIndex ? weekendLabelStyle : dayLabelStyle }
                     className={ this.props.dayLabelClassName }
                     role="columnheader">
                   { dayAbbr }
@@ -1006,7 +1003,7 @@ export default class DatePicker extends Component {
       };
     }
 
-    if (this.props.styleWeekend && currentDate.getDay() === this.localeData.weekEnd) {
+    if (currentDate.getDay() === this.localeData.weekEnd) {
       dayStyle = {
         ...dayStyle,
         ...defaultStyle.weekendStyle,

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -108,6 +108,8 @@ export default class DatePicker extends Component {
   constructor(properties) {
     super(properties);
     let selectedDate;
+    let month;
+    let year;
 
     if (has(properties, 'valueLink')) {
       selectedDate = properties.valueLink.value;
@@ -117,12 +119,28 @@ export default class DatePicker extends Component {
       selectedDate = properties.defaultValue;
     }
 
+    if (properties.month) {
+      month = properties.month - 1;
+    } else if (selectedDate) {
+      month = selectedDate.getMonth();
+    } else {
+      month = CURRENT_MONTH;
+    }
+
+    if (properties.year) {
+      year = properties.month;
+    } else if (selectedDate) {
+      year = selectedDate.getFullYear();
+    } else {
+      year = CURRENT_YEAR;
+    }
+
     this.state = {
       isFocused: false,
       isActive: false,
       selectedDate: selectedDate,
-      month: properties.month - 1,
-      year: properties.year,
+      month: month,
+      year: year,
     };
 
     this.localeData = getLocaleData(properties.locale);
@@ -254,8 +272,6 @@ export default class DatePicker extends Component {
   };
 
   static defaultProps = {
-    month: CURRENT_MONTH + 1,
-    year: CURRENT_YEAR,
     tabIndex: 0,
     'aria-label': 'datepicker',
     disabled: false,

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -8,9 +8,7 @@ import {
   getWeekArrayForMonth,
   getLastDayForMonth,
   getLocaleData,
-  CURRENT_DATE,
-  CURRENT_MONTH,
-  CURRENT_YEAR
+  today,
 } from '../utils/date-helpers';
 import defaultStyle from '../style/date-picker';
 import config from '../config/datePicker';
@@ -124,7 +122,7 @@ export default class DatePicker extends Component {
     } else if (selectedDate) {
       month = selectedDate.getMonth();
     } else {
-      month = CURRENT_MONTH;
+      month = today().getMonth();
     }
 
     if (properties.year) {
@@ -132,7 +130,7 @@ export default class DatePicker extends Component {
     } else if (selectedDate) {
       year = selectedDate.getFullYear();
     } else {
-      year = CURRENT_YEAR;
+      year = today().getFullYear();
     }
 
     this.state = {
@@ -340,8 +338,8 @@ export default class DatePicker extends Component {
         if (!this.state.focusedDateKey) {
           if (this.state.selectedDate && this.state.selectedDate.getMonth() === this.state.month && this.state.selectedDate.getFullYear() === this.state.year) {
             newState.focusedDateKey = convertDateToDateKey(this.state.selectedDate);
-          } else if (this.state.month === CURRENT_MONTH && this.state.year === CURRENT_YEAR) {
-            newState.focusedDateKey = getDateKey(CURRENT_YEAR, CURRENT_MONTH + 1, CURRENT_DATE);
+          } else if (this.state.month === today().getMonth() && this.state.year === today().getFullYear()) {
+            newState.focusedDateKey = getDateKey(today().getFullYear(), today().getMonth() + 1, today().getDate());
           } else {
             newState.focusedDateKey = getDateKey(this.state.year, this.state.month + 1, 1);
           }
@@ -1006,7 +1004,7 @@ export default class DatePicker extends Component {
       };
     }
 
-    if (day === CURRENT_DATE && month === CURRENT_MONTH && year === CURRENT_YEAR) {
+    if (day === today().getDate() && month === today().getMonth() && year === today().getFullYear()) {
       dayStyle = {
         ...dayStyle,
         ...defaultStyle.todayStyle,

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -376,8 +376,10 @@ export default class DatePicker extends Component {
    */
   componentWillReceiveProps(properties) {
     const newState = {
-      month: properties.month - 1,
-      year: properties.year,
+      // commenting these out to fix issue in docs for date components breaking after locale change
+      // we need a better algo about how to update month and year when date picker recieve props
+      // month: properties.month - 1,
+      // year: properties.year,
     };
 
     if (has(properties, 'valueLink')) {
@@ -980,6 +982,7 @@ export default class DatePicker extends Component {
    * 2. If active apply activeStyles
    */
   _renderNavBar() {
+    console.log('*****', this.localeData.monthNames[this.state.month]);
     const navBarStyle = {
       ...defaultStyle.navBarStyle,
       ...this.props.navBarStyle,

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -184,15 +184,6 @@ export default class DatePicker extends Component {
     onTouchEnd: PropTypes.func,
     onTouchCancel: PropTypes.func,
 
-    // event callbacks for days
-    onDayMouseOver: PropTypes.func,
-    onDayMouseOut: PropTypes.func,
-    onDayMouseDown: PropTypes.func,
-    onDayMouseUp: PropTypes.func,
-    onDayTouchStart: PropTypes.func,
-    onDayTouchEnd: PropTypes.func,
-    onDayTouchCancel: PropTypes.func,
-
     // callbacks for change of values
     onUpdate: PropTypes.func,
     onMonthUpdate: PropTypes.func,
@@ -551,8 +542,8 @@ export default class DatePicker extends Component {
       });
     }
 
-    if (this.props.onDayMouseDown) {
-      this.props.onDayMouseDown(event);
+    if (this.props.dayProps && this.props.dayProps.onMouseDown) {
+      this.props.dayProps.onMouseDown(event);
     }
   }
 
@@ -574,8 +565,8 @@ export default class DatePicker extends Component {
       });
     }
 
-    if (this.props.onDayMouseUp) {
-      this.props.onDayMouseUp(event);
+    if (this.props.dayProps && this.props.dayProps.onMouseUp) {
+      this.props.dayProps.onMouseUp(event);
     }
   }
 
@@ -589,8 +580,8 @@ export default class DatePicker extends Component {
       });
     }
 
-    if (this.props.onDayMouseOver) {
-      this.props.onDayMouseOver(event);
+    if (this.props.dayProps && this.props.dayProps.onMouseOver) {
+      this.props.dayProps.onMouseOver(event);
     }
   }
 
@@ -605,8 +596,8 @@ export default class DatePicker extends Component {
       });
     }
 
-    if (this.props.onDayMouseOut) {
-      this.props.onDayMouseOut(event);
+    if (this.props.dayProps && this.props.dayProps.onMouseOut) {
+      this.props.dayProps.onMouseOut(event);
     }
   }
 
@@ -621,8 +612,8 @@ export default class DatePicker extends Component {
       });
     }
 
-    if (this.props.onDayTouchStart) {
-      this.props.onDayTouchStart(event);
+    if (this.props.dayProps && this.props.dayProps.onTouchStart) {
+      this.props.dayProps.onTouchStart(event);
     }
   }
 
@@ -640,8 +631,8 @@ export default class DatePicker extends Component {
       }
     }
 
-    if (this.props.onDayTouchEnd) {
-      this.props.onDayTouchEnd(event);
+    if (this.props.dayProps && this.props.dayProps.onTouchEnd) {
+      this.props.dayProps.onTouchEnd(event);
     }
   }
 
@@ -650,8 +641,8 @@ export default class DatePicker extends Component {
       activeDay: undefined,
     });
 
-    if (this.props.onDayTouchCancel) {
-      this.props.onDayTouchCancel(event);
+    if (this.props.dayProps && this.props.dayProps.onTouchCancel) {
+      this.props.dayProps.onTouchCancel(event);
     }
   }
 

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -25,10 +25,11 @@ function sanitizeWrapperProps(properties) {
     'onBlur',
     'onKeyDown',
     'onMouseDown',
-    'onTouchCancel',
     'onMouseUp',
     'onTouchStart',
     'onTouchEnd',
+    'onTouchCancel',
+    'aria-label',
     'disabled',
     'style',
     'className',
@@ -142,7 +143,7 @@ export default class DatePicker extends Component {
     };
 
     this.localeData = getLocaleData(properties.locale);
-    this.wrapperProps = sanitizeWrapperProps(properties.wrapperProps);
+    this.wrapperProps = sanitizeWrapperProps(properties);
     this.dayProps = sanitizeDayProps(properties.dayProps);
     this.preventFocusStyleForTouchAndClick = has(properties, 'preventFocusStyleForTouchAndClick') ? properties.preventFocusStyleForTouchAndClick : config.preventFocusStyleForTouchAndClick;
   }
@@ -189,11 +190,10 @@ export default class DatePicker extends Component {
     onMonthUpdate: PropTypes.func,
 
     // props for wrapper and day
-    wrapperProps: PropTypes.object,
     dayProps: PropTypes.object,
 
     // ClassNames
-    wrapperClassName: PropTypes.string,
+    className: PropTypes.string,
     navBarClassName: PropTypes.string,
     prevMonthNavClassName: PropTypes.string,
     prevMonthNavIconClassName: PropTypes.string,
@@ -290,7 +290,7 @@ export default class DatePicker extends Component {
     this.setState(newState);
 
     this.localeData = getLocaleData(properties.locale);
-    this.wrapperProps = sanitizeWrapperProps(properties.wrapperProps);
+    this.wrapperProps = sanitizeWrapperProps(properties);
     this.dayProps = sanitizeDayProps(properties.dayProps);
     this.preventFocusStyleForTouchAndClick = has(properties, 'preventFocusStyleForTouchAndClick') ? properties.preventFocusStyleForTouchAndClick : config.preventFocusStyleForTouchAndClick;
 
@@ -1134,7 +1134,6 @@ export default class DatePicker extends Component {
     return (
       <div ref="datePicker"
            tabIndex={ tabIndex }
-           disabled={ this.props.disabled }
            onFocus={ ::this._onFocus }
            onBlur={ ::this._onBlur }
            onKeyDown={ ::this._onKeyDown }
@@ -1147,7 +1146,9 @@ export default class DatePicker extends Component {
            aria-disabled={ this.props.disabled }
            aria-readonly={ this.props.readOnly }
            style={ style }
-           className={ unionClassNames(this.props.wrapperClassName, this.pseudoStyleIds.styleId) }
+           className={
+             unionClassNames(this.props.className, this.pseudoStyleIds.styleId)
+           }
            {...this.wrapperProps} >
         { this._renderNavBar() }
         <div role="grid" style={ defaultStyle.weekGroupStyle}>

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -184,16 +184,6 @@ export default class DatePicker extends Component {
     onTouchEnd: PropTypes.func,
     onTouchCancel: PropTypes.func,
 
-    // event callbacks for previous month and next month navigation links
-    onPrevMonthNavMouseDown: PropTypes.func,
-    onPrevMonthNavMouseUp: PropTypes.func,
-    onPrevMonthNavTouchStart: PropTypes.func,
-    onPrevMonthNavTouchEnd: PropTypes.func,
-    onNextMonthNavMouseDown: PropTypes.func,
-    onNextMonthNavMouseUp: PropTypes.func,
-    onNextMonthNavTouchStart: PropTypes.func,
-    onNextMonthNavTouchEnd: PropTypes.func,
-
     // event callbacks for days
     onDayMouseOver: PropTypes.func,
     onDayMouseOut: PropTypes.func,

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -932,7 +932,7 @@ export default class DatePicker extends Component {
     const day = currentDate.getDate();
     const month = currentDate.getMonth();
     const year = currentDate.getFullYear();
-    const isOtherMonth = currentDate.getMonth() !== this.state.month;
+    const isOtherMonth = month !== this.state.month;
     const dateKey = convertDateToDateKey(currentDate);
 
     let ariaCurrent = '';
@@ -982,7 +982,7 @@ export default class DatePicker extends Component {
       };
     }
 
-    if (day === CURRENT_DATE && this.state.month === CURRENT_MONTH && this.state.year === CURRENT_YEAR) {
+    if (day === CURRENT_DATE && month === CURRENT_MONTH && year === CURRENT_YEAR) {
       dayStyle = {
         ...dayStyle,
         ...defaultStyle.todayStyle,

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -2,7 +2,16 @@ import React, {Component, PropTypes} from 'react';
 import {injectStyles, removeAllStyles} from '../utils/inject-style';
 import unionClassNames from '../utils/union-class-names';
 import {has, map, shift, reverse, omit} from '../utils/helpers';
-import {getWeekArrayForMonth, getLastDayForMonth, getLocaleData, CURRENT_DATE, CURRENT_MONTH, CURRENT_YEAR} from '../utils/date-helpers';
+import {
+  convertDateToDateKey,
+  getDateKey,
+  getWeekArrayForMonth,
+  getLastDayForMonth,
+  getLocaleData,
+  CURRENT_DATE,
+  CURRENT_MONTH,
+  CURRENT_YEAR
+} from '../utils/date-helpers';
 import defaultStyle from '../style/date-picker';
 import config from '../config/datePicker';
 import ActionArea from './ActionArea';
@@ -87,14 +96,6 @@ function updatePseudoClassStyle(pseudoStyleIds, properties, preventFocusStyleFor
   });
   injectStyles(styles);
 }
-
-const getDateKey = (year, month, day) => {
-  return `${year}-${month}-${day}`;
-};
-
-const convertDateToDateKey = (date) => {
-  return getDateKey(date.getFullYear(), date.getMonth() + 1, date.getDate());
-};
 
 /**
  * DatePicker React Component.

--- a/src/style/date-picker.js
+++ b/src/style/date-picker.js
@@ -156,7 +156,7 @@ const datePickerStyle = {
   },
 
   weekendLabelStyle: {
-    color: '#8E8071',
+    // color: '#8E8071',
   },
 
   // styling for individual day

--- a/src/style/date-picker.js
+++ b/src/style/date-picker.js
@@ -177,6 +177,7 @@ const datePickerStyle = {
     paddingTop: 5,
     position: 'relative',
     zIndex: 100,
+    cursor: 'default',
 
     /*
      To avoid any kind of flickering the user won't get feedback
@@ -199,7 +200,6 @@ const datePickerStyle = {
   },
 
   readOnlyDayStyle: {
-    cursor: 'auto',
   },
 
   activeDayStyle: {
@@ -221,9 +221,8 @@ const datePickerStyle = {
     cursor: 'not-allowed',
   },
 
-  disabledHoverDayStyle: {
+  disabledFocusDayStyle: {
     cursor: 'not-allowed',
-    backgroundColor: 'red',
   },
 
   todayStyle: {

--- a/src/style/date-picker.js
+++ b/src/style/date-picker.js
@@ -32,7 +32,6 @@ const datePickerStyle = {
   },
 
   disabledStyle: {
-    backgroundColor: '#D8D8D8',
   },
 
   readOnlyStyle: {
@@ -154,7 +153,6 @@ const datePickerStyle = {
   },
 
   disabledDayLabelStyle: {
-    color: '#C1BABA',
   },
 
   weekendLabelStyle: {

--- a/src/style/date-picker.js
+++ b/src/style/date-picker.js
@@ -120,7 +120,7 @@ const datePickerStyle = {
   },
 
   // styling for entire grid of week-header and weeks
-  weekGroupStyle: {
+  weekGridStyle: {
     boxSizing: 'border-box',
     overflow: 'auto',
     paddingBottom: 1,

--- a/src/utils/date-helpers.js
+++ b/src/utils/date-helpers.js
@@ -61,6 +61,14 @@ export function getLocaleData(locale) {
   return localeResult;
 }
 
+export const getDateKey = (year, month, day) => {
+  return `${year}-${month}-${day}`;
+};
+
+export const convertDateToDateKey = (date) => {
+  return getDateKey(date.getFullYear(), date.getMonth() + 1, date.getDate());
+};
+
 export const TODAY = new Date();
 
 export const CURRENT_DATE = TODAY.getDate();

--- a/src/utils/date-helpers.js
+++ b/src/utils/date-helpers.js
@@ -69,10 +69,4 @@ export const convertDateToDateKey = (date) => {
   return getDateKey(date.getFullYear(), date.getMonth() + 1, date.getDate());
 };
 
-export const TODAY = new Date();
-
-export const CURRENT_DATE = TODAY.getDate();
-
-export const CURRENT_MONTH = TODAY.getMonth();
-
-export const CURRENT_YEAR = TODAY.getFullYear();
+export const today = () => new Date();

--- a/src/utils/date-helpers.js
+++ b/src/utils/date-helpers.js
@@ -8,7 +8,7 @@ import {localeData} from '../config/i18n';
  * @param {number} firstDayOfWeek: first day of the week in the locale
  * @returns {Array}: Array of weeks in a month, each week is in turn array of days in that week
  */
-export function getWeekArrayForMonth(month, year, firstDayOfWeek) {
+export const getWeekArrayForMonth = (month, year, firstDayOfWeek) => {
   const monthDay = new Date(year, month, 1);
 
   // Todo: simplify this calculation of first date
@@ -30,18 +30,18 @@ export function getWeekArrayForMonth(month, year, firstDayOfWeek) {
   }
 
   return weekArray;
-}
+};
 
-export function getLastDayForMonth(year, month) {
+export const getLastDayForMonth = (year, month) => {
   return new Date(year, month + 1, 0);
-}
+};
 
 /**
  * Function will return locale data for locale. If data is not available in config files it will return default data.
  * @param locale - locale for which data is needed.
  * @returns {Object}: Object containing locale data.
  */
-export function getLocaleData(locale) {
+export const getLocaleData = (locale) => {
   const localeResult = {};
   let lData;
   if (locale) {
@@ -59,7 +59,7 @@ export function getLocaleData(locale) {
   localeResult.weekEnd = (lData && lData.weekEnd) ? lData.weekEnd : 0;
   localeResult.isRTL = (lData && lData.isRTL) ? lData.isRTL : false;
   return localeResult;
-}
+};
 
 export const getDateKey = (year, month, day) => {
   return `${year}-${month}-${day}`;


### PR DESCRIPTION
Relevant changes:

- introduce min & max
- fix: today styling is only applied to the currents month day
- improve disabled styling
- replaced custom classNames with props
- added 2 child props (there were only 2 left to make it complete)
- focus on month/year of the pre selected date by default
- fix: make sure today is called instead of generated while the module is loaded (would cause trouble on long running nodejs modules)