### PR TITLE
Remove Reactiflux reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To run the test continuously you can use `npm run test:watch`.
 
 ## Discussion or need help?
 
-Join us at the **#belle** channel of the [Reactiflux](http://reactiflux.com/) Slack community or our [Gitter room](https://gitter.im/nikgraf/belle).
+Join us at our [Gitter room](https://gitter.im/nikgraf/belle).
 
 In addition you can ask the community by [posting your question to StackOverflow with the **belle** tag.](http://stackoverflow.com/questions/ask?tags=belle).
 


### PR DESCRIPTION
I'm one of the mods of Reactiflux, excess channels has been brought up as an issue for new users (partly because Discord is opt-out instead of opt-in). I'd like to remove the Belle channel since it hasn't had any activity in a few weeks.