### PR TITLE
chore(dependencies): upgrade react, react-router, and jest

### DIFF
--- a/docs/components/Configuration.js
+++ b/docs/components/Configuration.js
@@ -309,13 +309,15 @@ export default class Configuration extends Component {
 
       <p>
         Localization support exist for date picker component. For date picker following parameters are required to be provided for a locale:
-        <ul>
-          <li><span style={{ fontWeight: 'bold' }}>monthNames</span>: Array for month names from January to December</li>
-          <li><span style={{ fontWeight: 'bold' }}>dayNamesMin</span>: Array for day short names</li>
-          <li><span style={{ fontWeight: 'bold' }}>firstDay</span>: First day of week (0 for Sunday, 1 for Monday, ...)</li>
-          <li><span style={{ fontWeight: 'bold' }}>weekEnd</span>: Weekend in that locale (0 for Sunday, 1 for Monday, ...)</li>
-          <li><span style={{ fontWeight: 'bold' }}>isRTL</span>: The text in that locale is written from right to left</li>
-        </ul>
+      </p>
+      <ul>
+        <li><span style={{ fontWeight: 'bold' }}>monthNames</span>: Array for month names from January to December</li>
+        <li><span style={{ fontWeight: 'bold' }}>dayNamesMin</span>: Array for day short names</li>
+        <li><span style={{ fontWeight: 'bold' }}>firstDay</span>: First day of week (0 for Sunday, 1 for Monday, ...)</li>
+        <li><span style={{ fontWeight: 'bold' }}>weekEnd</span>: Weekend in that locale (0 for Sunday, 1 for Monday, ...)</li>
+        <li><span style={{ fontWeight: 'bold' }}>isRTL</span>: The text in that locale is written from right to left</li>
+      </ul>
+      <p>
         In case any of these fields is not provided the defaults for English calendar will be used.
       </p>
 

--- a/docs/components/Home.js
+++ b/docs/components/Home.js
@@ -54,7 +54,7 @@ export default class Home extends Component {
                           marginLeft: 60, }}
             >React Core Team</div>
           </div>
-          <div stlye={{ clear: 'both' }}></div>
+          <div style={{ clear: 'both' }}></div>
         </div>
 
         <h3>Browser Support</h3>

--- a/docs/components/guides/IntroducingBelle.js
+++ b/docs/components/guides/IntroducingBelle.js
@@ -92,7 +92,7 @@ export default class Why extends Component {
             React Core Team
           </div>
         </div>
-        <div stlye={{ clear: 'both' }}></div>
+        <div style={{ clear: 'both' }}></div>
       </div>
 
       <p>Let’s have a look at two of the components and walk you through some of the details we took care of.</p>

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,10 +15,10 @@
   "dependencies": {
     "highlight.js": "=9.2.0",
     "history": "^2.0.1",
-    "react": "=15.0.0-rc.2",
-    "react-addons-linked-state-mixin": "^=15.0.0-rc.2",
-    "react-dom": "^=15.0.0-rc.2",
-    "react-router": "=v2.0.1",
+    "react": "^=15.3.2",
+    "react-addons-linked-state-mixin": "^=15.3.2",
+    "react-dom": "^=15.3.2",
+    "react-router": "=v2.5.2",
     "uglify-js": "=2.6.2",
     "underscore": "=1.8.3"
   },

--- a/examples/components/DatePickerPlayground.js
+++ b/examples/components/DatePickerPlayground.js
@@ -6,7 +6,7 @@ export default React.createClass({
   _renderDay(day) {
     const date = day.getDate();
     return (
-      <div onMouseDown={::this._onMouseDown}>
+      <div onMouseDown={this._onMouseDown}>
         🎁{ date }
       </div>
     );

--- a/examples/components/SelectPlayground.js
+++ b/examples/components/SelectPlayground.js
@@ -28,8 +28,8 @@ export default React.createClass({
       <div>
         <h2>Select</h2>
 
-        <h3>Native Select with value</h3>
-        <select value="B">
+        <h3>Native Select with value (read-only)</h3>
+        <select value="B" readOnly>
           <option value="A">Apple</option>
           <option value="B">Banana</option>
           <option value="C">Cranberry</option>

--- a/examples/package.json
+++ b/examples/package.json
@@ -13,9 +13,9 @@
     "url": "http://github.com/nikgraf/belle.git"
   },
   "dependencies": {
-    "react": "=15.0.0-rc.2",
-    "react-addons-linked-state-mixin": "^15.0.0-rc.2",
-    "react-dom": "^15.0.0-rc.2",
+    "react": "=15.3.2",
+    "react-addons-linked-state-mixin": "^15.3.2",
+    "react-dom": "^15.3.2",
     "underscore": "=1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "react-component"
   ],
   "peerDependencies": {
-    "react": ">=0.14.0 || ^15.0.0-rc",
-    "react-dom": ">=0.14.0 || ^15.0.0-rc"
+    "react": ">=0.14.0",
+    "react-dom": ">=0.14.0"
   },
   "scripts": {
     "build": "BABEL_ENV=production node_modules/.bin/babel --out-dir='lib' --ignore='__tests__/*' src",
@@ -57,11 +57,11 @@
     "eslint-config-airbnb": "6.2.0",
     "eslint-plugin-mocha": "^2.0.0",
     "eslint-plugin-react": "^4.2.3",
-    "jest-cli": "^0.9.2",
+    "jest-cli": "^15.1.1",
     "jscs": "^2.11.0",
-    "react": "^15.0.0-rc.2",
-    "react-addons-test-utils": "^15.0.0-rc.2",
-    "react-dom": "^15.0.0-rc.2",
+    "react": "^15.3.2",
+    "react-addons-test-utils": "^15.3.2",
+    "react-dom": "^15.3.2",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
     "redbox-react": "^1.2.2",
@@ -70,7 +70,8 @@
     "webpack-hot-middleware": "^2.10.0"
   },
   "jest": {
-    "testRunner": "<rootDir>/node_modules/jest-cli/src/testRunners/jasmine/jasmine2.js",
+    "testRunner": "jasmine2",
+    "automock": true,
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react",
       "<rootDir>/node_modules/fbjs",
@@ -80,8 +81,7 @@
       "../utils/union-class-names",
       "../utils/is-component-of-type"
     ],
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
-    "preprocessCachingDisabled": true
+    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/__tests__/ComboBox-test.js
+++ b/src/__tests__/ComboBox-test.js
@@ -33,7 +33,7 @@ describe('ComboBox', () => {
       </ComboBox>
     );
 
-    expect(combobox.state.inputValue).toBe(undefined);
+    expect(combobox.state.inputValue).toBe('');
     expect(React.Children.count(combobox.filteredOptions)).toBe(2);
   });
 

--- a/src/__tests__/DatePicker-test.js
+++ b/src/__tests__/DatePicker-test.js
@@ -46,7 +46,7 @@ describe('DatePicker', () => {
     const dayPickerWrapper = TestUtils.scryRenderedDOMComponentsWithClass(datePicker, 'date_picker_wrapper')[0];
     TestUtils.Simulate.focus(dayPickerWrapper);
     TestUtils.Simulate.keyDown(dayPickerWrapper, { key: 'Enter' });
-    expect(datePicker.state.selectedDate).toBeGreaterThan(0);
+    expect(+datePicker.state.selectedDate).toBeGreaterThan(0);
   });
 
   describe('injecting styles', () => {
@@ -84,8 +84,8 @@ describe('DatePicker', () => {
     const dayPickerWrapper = TestUtils.scryRenderedDOMComponentsWithClass(datePicker, 'date_picker_wrapper')[0];
     TestUtils.Simulate.focus(dayPickerWrapper);
     TestUtils.Simulate.keyDown(dayPickerWrapper, { key: ' ' });
-    expect(datePicker.state.selectedDate).toBeGreaterThan(0);
-    expect(dateSelected).toBeGreaterThan(0);
+    expect(+datePicker.state.selectedDate).toBeGreaterThan(0);
+    expect(+dateSelected).toBeGreaterThan(0);
 
     // expect(dateSelected.getDay()).toBeGreaterThan(0);
     TestUtils.Simulate.keyDown(dayPickerWrapper, { key: ' ' });
@@ -236,7 +236,7 @@ describe('DatePicker', () => {
     const datePickerDays = TestUtils.scryRenderedDOMComponentsWithClass(datePicker, 'date_picker_day');
     const firstDay = ReactDOM.findDOMNode(datePickerDays[0]).textContent;
     const secondDay = ReactDOM.findDOMNode(datePickerDays[1]).textContent;
-    expect(firstDay).toBeGreaterThan(secondDay);
+    expect(+firstDay).toBeGreaterThan(+secondDay);
   });
 
   it('should change selectedDate when a day receives mouseDown with button 0', () => {
@@ -251,12 +251,12 @@ describe('DatePicker', () => {
     TestUtils.Simulate.mouseDown(day, { button: 0 });
     TestUtils.Simulate.mouseUp(day, { button: 0 });
     const newDate = datePicker.state.selectedDate;
-    expect(datePicker.state.selectedDate).toBeGreaterThan(0);
+    expect(+datePicker.state.selectedDate).toBeGreaterThan(0);
     expect(dateSelected.getDay()).toBeGreaterThan(0);
     day = TestUtils.scryRenderedDOMComponentsWithClass(datePicker, 'day_test')[10];
     TestUtils.Simulate.mouseDown(day, { button: 1 });
     TestUtils.Simulate.mouseUp(day, { button: 1 });
-    expect(datePicker.state.selectedDate).toBe(newDate);
+    expect(+datePicker.state.selectedDate).toBe(+newDate);
   });
 
   it('should not change selectedDate in state if component uses value property', () => {

--- a/src/components/ActionArea.js
+++ b/src/components/ActionArea.js
@@ -1,5 +1,30 @@
 import React, { Component, PropTypes } from 'react';
 import actionAreaStyle from '../style/actionArea';
+import { omit } from '../utils/helpers';
+
+const actionAreaPropTypes = {
+  activeStyle: PropTypes.object,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  hoverStyle: PropTypes.object,
+  onTouchStart: PropTypes.func,
+  onTouchEnd: PropTypes.func,
+  onTouchCancel: PropTypes.func,
+  onMouseDown: PropTypes.func,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+
+  // TODO investigate how we solve mouseUp in other compents (like the right click edgecase)
+  onMouseUp: PropTypes.func,
+  onUpdate: PropTypes.func,
+  style: PropTypes.object,
+};
+
+function sanitizeChildProps(properties) {
+  return omit(properties, Object.keys(actionAreaPropTypes));
+}
 
 /**
  * ActionArea
@@ -16,31 +41,11 @@ export default class ActionArea extends Component {
 
   constructor(properties) {
     super(properties);
-    const { style, ...childProps } = properties; // eslint-disable-line no-unused-vars
-    this.childProps = childProps;
+    this.childProps = sanitizeChildProps(properties);
   }
 
   static displayName = 'ActionArea';
-
-  static propTypes = {
-    activeStyle: PropTypes.object,
-    children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node,
-    ]),
-    hoverStyle: PropTypes.object,
-    onTouchStart: PropTypes.func,
-    onTouchEnd: PropTypes.func,
-    onTouchCancel: PropTypes.func,
-    onMouseDown: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-
-    // TODO investigate how we solve mouseUp in other compents (like the right click edgecase)
-    onMouseUp: PropTypes.func,
-    onUpdate: PropTypes.func,
-    style: PropTypes.object,
-  };
+  static propTypes = actionAreaPropTypes;
 
   state = {
     // Note: On touch devices mouseEnter is fired while mouseLeave is not.
@@ -58,8 +63,7 @@ export default class ActionArea extends Component {
    * Update the childProps based on the updated properties passed to the card.
    */
   componentWillReceiveProps(properties) {
-    const { style, ...childProps } = properties; // eslint-disable-line no-unused-vars
-    this.childProps = childProps;
+    this.childProps = sanitizeChildProps(properties);
   }
 
   /**

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,11 +1,37 @@
 import React, { Component, PropTypes } from 'react'; // eslint-disable-line no-unused-vars
-import { has, uniqueId } from '../utils/helpers';
+import { has, omit, uniqueId } from '../utils/helpers';
 import buttonStyle from '../style/button';
 import unionClassNames from '../utils/union-class-names';
 import { injectStyles, removeStyle } from '../utils/inject-style';
 import config from '../config/button';
 
 const buttonTypes = ['button', 'submit', 'reset']; // eslint-disable-line no-unused-vars
+
+const buttonPropTypes = {
+  activeStyle: PropTypes.object,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  type: PropTypes.oneOf(buttonTypes),
+  style: PropTypes.object,
+  focusStyle: PropTypes.object,
+  hoverStyle: PropTypes.object,
+  disabledStyle: PropTypes.object,
+  disabledHoverStyle: PropTypes.object,
+  onTouchStart: PropTypes.func,
+  onTouchEnd: PropTypes.func,
+  onTouchCancel: PropTypes.func,
+  onMouseDown: PropTypes.func,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  preventFocusStyleForTouchAndClick: PropTypes.bool,
+  primary: PropTypes.bool,
+};
 
 /**
  * Returns an object with properties that are relevant for the button element.
@@ -14,26 +40,7 @@ const buttonTypes = ['button', 'submit', 'reset']; // eslint-disable-line no-unu
  * set to `button`.
  */
 function sanitizeChildProps(properties) {
-  const {
-    className, // eslint-disable-line no-unused-vars
-    style, // eslint-disable-line no-unused-vars
-    hoverStyle, // eslint-disable-line no-unused-vars
-    focusStyle, // eslint-disable-line no-unused-vars
-    activeStyle, // eslint-disable-line no-unused-vars
-    disabledStyle, // eslint-disable-line no-unused-vars
-    disabledHoverStyle, // eslint-disable-line no-unused-vars
-    primary, // eslint-disable-line no-unused-vars
-    onTouchStart, // eslint-disable-line no-unused-vars
-    onTouchEnd, // eslint-disable-line no-unused-vars
-    onTouchCancel, // eslint-disable-line no-unused-vars
-    onMouseDown, // eslint-disable-line no-unused-vars
-    onMouseEnter, // eslint-disable-line no-unused-vars
-    onMouseLeave, // eslint-disable-line no-unused-vars
-    onFocus, // eslint-disable-line no-unused-vars
-    onBlur, // eslint-disable-line no-unused-vars
-    ...childProps,
-  } = properties;
-  return childProps;
+  return omit(properties, Object.keys(buttonPropTypes));
 }
 
 /**
@@ -132,31 +139,7 @@ export default class Button extends Component {
 
   static displayName = 'Button';
 
-  static propTypes = {
-    activeStyle: PropTypes.object,
-    children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node,
-    ]),
-    className: PropTypes.string,
-    disabled: PropTypes.bool,
-    type: PropTypes.oneOf(buttonTypes),
-    style: PropTypes.object,
-    focusStyle: PropTypes.object,
-    hoverStyle: PropTypes.object,
-    disabledStyle: PropTypes.object,
-    disabledHoverStyle: PropTypes.object,
-    onTouchStart: PropTypes.func,
-    onTouchEnd: PropTypes.func,
-    onTouchCancel: PropTypes.func,
-    onMouseDown: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    onFocus: PropTypes.func,
-    onBlur: PropTypes.func,
-    preventFocusStyleForTouchAndClick: PropTypes.bool,
-    primary: PropTypes.bool,
-  };
+  static propTypes = buttonPropTypes;
 
   static defaultProps = {
     primary: false,
@@ -375,6 +358,8 @@ export default class Button extends Component {
         onMouseDown={ this._onMouseDown }
         onMouseEnter={ this._onMouseEnter }
         onMouseLeave={ this._onMouseLeave }
+        disabled={ this.props.disabled }
+        type={ this.props.type }
         {...this.state.childProps}
       >
         { this.props.children }

--- a/src/components/ComboBox.js
+++ b/src/components/ComboBox.js
@@ -5,6 +5,45 @@ import { omit, filterReactChildren, has, isEmpty, find, getArrayForReactChildren
 import style from '../style/combo-box';
 import ComboBoxItem from '../components/ComboBoxItem';
 
+const comboBoxPropTypes = {
+  children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  defaultValue: PropTypes.string,
+  value: PropTypes.string,
+  valueLink: PropTypes.shape({
+    value: PropTypes.string,
+    requestChange: PropTypes.func.isRequired,
+  }),
+  placeholder: PropTypes.string,
+  disabled: PropTypes.bool,
+  wrapperProps: PropTypes.object,
+  menuProps: PropTypes.object,
+  caretProps: PropTypes.object,
+  onUpdate: PropTypes.func,
+  onInputMatch: PropTypes.func,
+  tabIndex: PropTypes.number,
+  onKeyDown: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  className: PropTypes.string,
+  caretClassName: PropTypes.string,
+  style: PropTypes.object,
+  wrapperStyle: PropTypes.object,
+  hintStyle: PropTypes.object,
+  menuStyle: PropTypes.object,
+  focusStyle: PropTypes.object,
+  disabledStyle: PropTypes.object,
+  disabledHoverStyle: PropTypes.object,
+  hoverStyle: PropTypes.object,
+  caretToOpenStyle: PropTypes.object,
+  caretToCloseStyle: PropTypes.object,
+  disabledCaretToOpenStyle: PropTypes.object,
+  maxOptions: PropTypes.number,
+  displayCaret: PropTypes.bool,
+  enableHint: PropTypes.bool,
+  filterFunc: PropTypes.func,
+  'aria-label': PropTypes.string,
+};
+
 /**
  * Update hover style for the specified styleId.
  *
@@ -70,26 +109,7 @@ function sanitizeWrapperProps(properties) {
  * Returns an object with properties that are relevant for the input box.
  */
 function sanitizeInputProps(properties) {
-  return omit(properties, [
-    'ref',
-    'value',
-    'valueLink',
-    'defaultValue',
-    'placeholder',
-    'disabled',
-    'hintStyle',
-    'className',
-    'style',
-    'onUpdate',
-    'onInputMatch',
-    'tabIndex',
-    'onBlur',
-    'onFocus',
-    'onKeyDown',
-    'aria-disabled',
-    'aria-autocomplete',
-    'children',
-  ]);
+  return omit(properties, Object.keys(comboBoxPropTypes));
 }
 
 /**
@@ -147,7 +167,7 @@ export default class ComboBox extends Component {
     this.state = {
       isOpen: false,
       focusedOptionIndex: undefined,
-      inputValue,
+      inputValue: inputValue || '',
       wrapperProps: sanitizeWrapperProps(properties.wrapperProps),
       inputProps: sanitizeInputProps(properties),
       caretProps: sanitizeCaretProps(properties.caretProps),
@@ -159,44 +179,7 @@ export default class ComboBox extends Component {
 
   static displayName = 'ComboBox';
 
-  static propTypes = {
-    children: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-    defaultValue: PropTypes.string,
-    value: PropTypes.string,
-    valueLink: PropTypes.shape({
-      value: PropTypes.string,
-      requestChange: PropTypes.func.isRequired,
-    }),
-    placeholder: PropTypes.string,
-    disabled: PropTypes.bool,
-    wrapperProps: PropTypes.object,
-    menuProps: PropTypes.object,
-    caretProps: PropTypes.object,
-    onUpdate: PropTypes.func,
-    onInputMatch: PropTypes.func,
-    tabIndex: PropTypes.number,
-    onKeyDown: PropTypes.func,
-    onFocus: PropTypes.func,
-    onBlur: PropTypes.func,
-    className: PropTypes.string,
-    caretClassName: PropTypes.string,
-    style: PropTypes.object,
-    wrapperStyle: PropTypes.object,
-    hintStyle: PropTypes.object,
-    menuStyle: PropTypes.object,
-    focusStyle: PropTypes.object,
-    disabledStyle: PropTypes.object,
-    disabledHoverStyle: PropTypes.object,
-    hoverStyle: PropTypes.object,
-    caretToOpenStyle: PropTypes.object,
-    caretToCloseStyle: PropTypes.object,
-    disabledCaretToOpenStyle: PropTypes.object,
-    maxOptions: PropTypes.number,
-    displayCaret: PropTypes.bool,
-    enableHint: PropTypes.bool,
-    filterFunc: PropTypes.func,
-    'aria-label': PropTypes.string,
-  };
+  static propTypes = comboBoxPropTypes;
 
   static childContextTypes = {
     isDisabled: PropTypes.bool.isRequired,
@@ -290,9 +273,9 @@ export default class ComboBox extends Component {
     };
 
     if (has(properties, 'valueLink')) {
-      newState.inputValue = properties.valueLink.value;
+      newState.inputValue = properties.valueLink.value || '';
     } else if (has(properties, 'value')) {
-      newState.inputValue = properties.value;
+      newState.inputValue = properties.value || '';
     }
 
     if (newState.inputValue) {
@@ -710,6 +693,7 @@ export default class ComboBox extends Component {
           style={ hintStyle }
           value={ hint }
           tabIndex = { -1 }
+          key="style-hint"
           readOnly
         />
 
@@ -726,6 +710,7 @@ export default class ComboBox extends Component {
           onFocus={ this._onFocus }
           onKeyDown={ this._onKeyDown }
           aria-autocomplete="list"
+          key="combo-input"
           {...this.state.inputProps}
         />
         <span

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -17,25 +17,113 @@ import ActionArea from './ActionArea';
 import DisabledDay from './DisabledDay';
 import Day from './Day';
 
+const datePickerPropTypes = {
+  // value related props
+  defaultValue: PropTypes.instanceOf(Date),
+  value: PropTypes.instanceOf(Date),
+  valueLink: PropTypes.shape({
+    value: PropTypes.instanceOf(Date),
+    requestChange: PropTypes.func.isRequired,
+  }),
+
+  min: PropTypes.instanceOf(Date),
+  max: PropTypes.instanceOf(Date),
+
+  // component config related props
+  locale: PropTypes.string,
+  month: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+  defaultMonth: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+  year: PropTypes.number,
+  defaultYear: PropTypes.number,
+  showOtherMonthDate: PropTypes.bool,
+  renderDay: PropTypes.func,
+  tabIndex: PropTypes.number,
+  'aria-label': PropTypes.string,
+  disabled: PropTypes.bool,
+  readOnly: PropTypes.bool,
+  preventFocusStyleForTouchAndClick: PropTypes.bool,
+
+  // event callbacks for wrapper
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  onMouseDown: PropTypes.func,
+  onMouseUp: PropTypes.func,
+  onTouchStart: PropTypes.func,
+  onTouchEnd: PropTypes.func,
+  onTouchCancel: PropTypes.func,
+
+  // callbacks for change of values
+  onUpdate: PropTypes.func,
+  onMonthUpdate: PropTypes.func,
+
+  // props
+  dayProps: PropTypes.object,
+  navBarProps: PropTypes.object,
+  prevMonthNavProps: PropTypes.object,
+  prevMonthNavIconProps: PropTypes.object,
+  nextMonthNavProps: PropTypes.object,
+  nextMonthNavIconProps: PropTypes.object,
+  monthLabelProps: PropTypes.object,
+  dayLabelProps: PropTypes.object,
+  weekHeaderProps: PropTypes.object,
+  weekGridProps: PropTypes.object,
+
+  // ClassNames
+  className: PropTypes.string,
+
+  // wrapper styles
+  style: PropTypes.object,
+  disabledStyle: PropTypes.object,
+  readOnlyStyle: PropTypes.object,
+  hoverStyle: PropTypes.object,
+  activeStyle: PropTypes.object,
+  focusStyle: PropTypes.object,
+  disabledHoverStyle: PropTypes.object,
+
+  // navbar styles
+  navBarStyle: PropTypes.object,
+
+  // prevMonthNav styles
+  prevMonthNavStyle: PropTypes.object,
+  prevMonthNavIconStyle: PropTypes.object,
+  hoverPrevMonthNavStyle: PropTypes.object,
+  activePrevMonthNavStyle: PropTypes.object,
+
+  // nextMonthNav styles
+  nextMonthNavStyle: PropTypes.object,
+  nextMonthNavIconStyle: PropTypes.object,
+  hoverNextMonthNavStyle: PropTypes.object,
+  activeNextMonthNavStyle: PropTypes.object,
+
+  weekHeaderStyle: PropTypes.object,
+
+  // monthlbl styles
+  monthLabelStyle: PropTypes.object,
+
+  // daylbl styles
+  dayLabelStyle: PropTypes.object,
+  disabledDayLabelStyle: PropTypes.object,
+  weekendLabelStyle: PropTypes.object,
+
+  // day styles
+  dayStyle: PropTypes.object,
+  disabledDayStyle: PropTypes.object,
+  readOnlyDayStyle: PropTypes.object,
+  activeDayStyle: PropTypes.object,
+  focusDayStyle: PropTypes.object,
+  disabledFocusDayStyle: PropTypes.object,
+  todayStyle: PropTypes.object,
+  selectedDayStyle: PropTypes.object,
+  otherMonthDayStyle: PropTypes.object,
+  weekendStyle: PropTypes.object,
+};
+
 /**
  * Returns an object with properties that are relevant for the wrapping div of the date picker.
  */
 function sanitizeWrapperProps(properties) {
-  return omit(properties, [
-    'tabIndex',
-    'onFocus',
-    'onBlur',
-    'onKeyDown',
-    'onMouseDown',
-    'onMouseUp',
-    'onTouchStart',
-    'onTouchEnd',
-    'onTouchCancel',
-    'aria-label',
-    'disabled',
-    'style',
-    'className',
-  ]);
+  return omit(properties, Object.keys(datePickerPropTypes));
 }
 
 /**
@@ -250,105 +338,7 @@ export default class DatePicker extends Component {
 
   static displayName = 'DatePicker';
 
-  static propTypes = {
-    // value related props
-    defaultValue: PropTypes.instanceOf(Date),
-    value: PropTypes.instanceOf(Date),
-    valueLink: PropTypes.shape({
-      value: PropTypes.instanceOf(Date),
-      requestChange: PropTypes.func.isRequired,
-    }),
-
-    min: PropTypes.instanceOf(Date),
-    max: PropTypes.instanceOf(Date),
-
-    // component config related props
-    locale: PropTypes.string,
-    month: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-    year: PropTypes.number,
-    showOtherMonthDate: PropTypes.bool,
-    renderDay: PropTypes.func,
-    tabIndex: PropTypes.number,
-    'aria-label': PropTypes.string,
-    disabled: PropTypes.bool,
-    readOnly: PropTypes.bool,
-    preventFocusStyleForTouchAndClick: PropTypes.bool,
-
-    // event callbacks for wrapper
-    onFocus: PropTypes.func,
-    onBlur: PropTypes.func,
-    onKeyDown: PropTypes.func,
-    onMouseDown: PropTypes.func,
-    onMouseUp: PropTypes.func,
-    onTouchStart: PropTypes.func,
-    onTouchEnd: PropTypes.func,
-    onTouchCancel: PropTypes.func,
-
-    // callbacks for change of values
-    onUpdate: PropTypes.func,
-    onMonthUpdate: PropTypes.func,
-
-    // props
-    dayProps: PropTypes.object,
-    navBarProps: PropTypes.object,
-    prevMonthNavProps: PropTypes.object,
-    prevMonthNavIconProps: PropTypes.object,
-    nextMonthNavProps: PropTypes.object,
-    nextMonthNavIconProps: PropTypes.object,
-    monthLabelProps: PropTypes.object,
-    dayLabelProps: PropTypes.object,
-    weekHeaderProps: PropTypes.object,
-    weekGridProps: PropTypes.object,
-
-    // ClassNames
-    className: PropTypes.string,
-
-    // wrapper styles
-    style: PropTypes.object,
-    disabledStyle: PropTypes.object,
-    readOnlyStyle: PropTypes.object,
-    hoverStyle: PropTypes.object,
-    activeStyle: PropTypes.object,
-    focusStyle: PropTypes.object,
-    disabledHoverStyle: PropTypes.object,
-
-    // navbar styles
-    navBarStyle: PropTypes.object,
-
-    // prevMonthNav styles
-    prevMonthNavStyle: PropTypes.object,
-    prevMonthNavIconStyle: PropTypes.object,
-    hoverPrevMonthNavStyle: PropTypes.object,
-    activePrevMonthNavStyle: PropTypes.object,
-
-    // nextMonthNav styles
-    nextMonthNavStyle: PropTypes.object,
-    nextMonthNavIconStyle: PropTypes.object,
-    hoverNextMonthNavStyle: PropTypes.object,
-    activeNextMonthNavStyle: PropTypes.object,
-
-    weekHeaderStyle: PropTypes.object,
-
-    // monthlbl styles
-    monthLabelStyle: PropTypes.object,
-
-    // daylbl styles
-    dayLabelStyle: PropTypes.object,
-    disabledDayLabelStyle: PropTypes.object,
-    weekendLabelStyle: PropTypes.object,
-
-    // day styles
-    dayStyle: PropTypes.object,
-    disabledDayStyle: PropTypes.object,
-    readOnlyDayStyle: PropTypes.object,
-    activeDayStyle: PropTypes.object,
-    focusDayStyle: PropTypes.object,
-    disabledFocusDayStyle: PropTypes.object,
-    todayStyle: PropTypes.object,
-    selectedDayStyle: PropTypes.object,
-    otherMonthDayStyle: PropTypes.object,
-    weekendStyle: PropTypes.object,
-  };
+  static propTypes = datePickerPropTypes;
 
   static defaultProps = {
     tabIndex: 0,

--- a/src/components/Option.js
+++ b/src/components/Option.js
@@ -2,18 +2,33 @@ import React, { Component, PropTypes } from 'react';
 import { omit } from '../utils/helpers';
 import style from '../style/option';
 
+const optionPropTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  style: PropTypes.object,
+  hoverStyle: PropTypes.object,
+  selectStyle: PropTypes.object,
+  disabledSelectStyle: PropTypes.object,
+  _isDisplayedAsSelected: PropTypes.bool,
+  value: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number,
+  ]).isRequired,
+  identifier: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+};
+
 /**
  * Returns an object with properties that are relevant for the wrapping div.
  */
 function sanitizeChildProps(properties) {
-  return omit(properties, [
-    'style',
-    'hoverStyle',
-    'selectStyle',
-    'disabledSelectStyle',
-    'value',
-    '_isDisplayedAsSelected',
-  ]);
+  return omit(properties, Object.keys(optionPropTypes));
 }
 
 /**
@@ -32,22 +47,7 @@ export default class Option extends Component {
 
   static displayName = 'Option';
 
-  static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node,
-    ]),
-    style: PropTypes.object,
-    hoverStyle: PropTypes.object,
-    selectStyle: PropTypes.object,
-    disabledSelectStyle: PropTypes.object,
-    _isDisplayedAsSelected: PropTypes.bool,
-    value: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.string,
-      PropTypes.number,
-    ]).isRequired,
-  };
+  static propTypes = optionPropTypes;
 
   static contextTypes = {
     isDisabled: PropTypes.bool.isRequired,

--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -2,11 +2,21 @@ import React, { Component, PropTypes } from 'react';
 import { omit } from '../utils/helpers';
 import style from '../style/placeholder';
 
+const placeholderPropTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  style: PropTypes.object,
+  disabledStyle: PropTypes.object,
+  _isDisabled: PropTypes.bool,
+};
+
 /**
  * Returns an object with properties that are relevant for the wrapping div.
  */
 function sanitizeChildProps(properties) {
-  return omit(properties, ['style', 'disabledStyle', '_isDisabled']);
+  return omit(properties, Object.keys(placeholderPropTypes));
 }
 
 /**
@@ -25,15 +35,7 @@ export default class Placeholder extends Component {
 
   static displayName = 'Placeholder';
 
-  static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node,
-    ]),
-    style: PropTypes.object,
-    disabledStyle: PropTypes.object,
-    _isDisabled: PropTypes.bool,
-  };
+  static propTypes = placeholderPropTypes;
 
   static defaultProps = {
     _isDisabled: false,

--- a/src/components/Rating.js
+++ b/src/components/Rating.js
@@ -7,38 +7,48 @@ import unionClassNames from '../utils/union-class-names';
 import config from '../config/rating';
 import { requestAnimationFrame, cancelAnimationFrame } from '../utils/animation-frame-management';
 
+const ratingPropTypes = {
+  defaultValue: PropTypes.oneOf([1, 2, 3, 4, 5]),
+  value: PropTypes.oneOf([1, 2, 3, 4, 5]),
+  valueLink: PropTypes.shape({
+    value: PropTypes.oneOf([1, 2, 3, 4, 5]),
+    requestChange: PropTypes.func.isRequired,
+  }),
+  disabled: PropTypes.bool,
+  tabIndex: PropTypes.number,
+  character: PropTypes.string,
+  characterProps: PropTypes.object,
+  preventFocusStyleForTouchAndClick: PropTypes.bool,
+  'aria-label': PropTypes.string,
+  style: PropTypes.object,
+  className: PropTypes.string,
+  focusStyle: PropTypes.object,
+  disabledStyle: PropTypes.object,
+  hoverStyle: PropTypes.object,
+  disabledHoverStyle: PropTypes.object,
+  characterStyle: PropTypes.object,
+  activeCharacterStyle: PropTypes.object,
+  hoverCharacterStyle: PropTypes.object,
+  onUpdate: PropTypes.func,
+  onMouseDown: PropTypes.func,
+  onMouseUp: PropTypes.func,
+  onMouseEnter: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  onTouchStart: PropTypes.func,
+  onTouchMove: PropTypes.func,
+  onTouchEnd: PropTypes.func,
+  onTouchCancel: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  onKeyDown: PropTypes.func,
+};
+
 /**
  * sanitize properties for the wrapping div.
  */
 function sanitizeWrapperProps(properties) {
-  return omit(properties, [
-    'className',
-    'onKeyDown',
-    'onMouseEnter',
-    'onMouseMove',
-    'onMouseLeave',
-    'onMouseUp',
-    'onMouseDown',
-    'onTouchStart',
-    'onTouchMove',
-    'onTouchEnd',
-    'onTouchCancel',
-    'onBlur',
-    'onFocus',
-    'tabIndex',
-    'aria-label',
-    'aria-valuemax',
-    'aria-valuemin',
-    'aria-valuenow',
-    'aria-disabled',
-    'style',
-    'focusStyle',
-    'disabledStyle',
-    'characterStyle',
-    'activeCharacterStyle',
-    'hoverCharacterStyle',
-    'characterProps',
-  ]);
+  return omit(properties, Object.keys(ratingPropTypes));
 }
 
 /**
@@ -110,42 +120,7 @@ export default class Rating extends Component {
 
   static displayName = 'Rating';
 
-  static propTypes = {
-    defaultValue: PropTypes.oneOf([1, 2, 3, 4, 5]),
-    value: PropTypes.oneOf([1, 2, 3, 4, 5]),
-    valueLink: PropTypes.shape({
-      value: PropTypes.oneOf([1, 2, 3, 4, 5]),
-      requestChange: PropTypes.func.isRequired,
-    }),
-    disabled: PropTypes.bool,
-    tabIndex: PropTypes.number,
-    character: PropTypes.string,
-    characterProps: PropTypes.object,
-    preventFocusStyleForTouchAndClick: PropTypes.bool,
-    'aria-label': PropTypes.string,
-    style: PropTypes.object,
-    className: PropTypes.string,
-    focusStyle: PropTypes.object,
-    disabledStyle: PropTypes.object,
-    hoverStyle: PropTypes.object,
-    disabledHoverStyle: PropTypes.object,
-    characterStyle: PropTypes.object,
-    activeCharacterStyle: PropTypes.object,
-    hoverCharacterStyle: PropTypes.object,
-    onUpdate: PropTypes.func,
-    onMouseDown: PropTypes.func,
-    onMouseUp: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseMove: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    onTouchStart: PropTypes.func,
-    onTouchMove: PropTypes.func,
-    onTouchEnd: PropTypes.func,
-    onTouchCancel: PropTypes.func,
-    onFocus: PropTypes.func,
-    onBlur: PropTypes.func,
-    onKeyDown: PropTypes.func,
-  };
+  static propTypes = ratingPropTypes;
 
   /**
    * Setting default prop values.

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -66,6 +66,51 @@ function validateChildrenAreOptionsAndMaximumOnePlaceholder(props, propName, com
   return undefined;
 }
 
+const selectPropTypes = {
+  children: validateChildrenAreOptionsAndMaximumOnePlaceholder,
+  value: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Date),
+  ]),
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  onUpdate: PropTypes.func,
+  valueLink: PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    requestChange: PropTypes.func.isRequired,
+  }),
+  className: PropTypes.string,
+  shouldPositionOptions: PropTypes.bool,
+  positionOptions: PropTypes.func,
+  style: PropTypes.object,
+  focusStyle: PropTypes.object,
+  hoverStyle: PropTypes.object,
+  activeStyle: PropTypes.object,
+  wrapperStyle: PropTypes.object,
+  menuStyle: PropTypes.object,
+  caretToOpenStyle: PropTypes.object,
+  caretToCloseStyle: PropTypes.object,
+  wrapperProps: PropTypes.object,
+  menuProps: PropTypes.object,
+  caretProps: PropTypes.object,
+  disabled: PropTypes.bool,
+  disabledStyle: PropTypes.object,
+  disabledHoverStyle: PropTypes.object,
+  disabledCaretToOpenStyle: PropTypes.object,
+  id: PropTypes.string,
+  onClick: PropTypes.func,
+  onTouchCancel: PropTypes.func,
+  onMouseDown: PropTypes.func,
+  onMouseUp: PropTypes.func,
+  onTouchEnd: PropTypes.func,
+  onTouchStart: PropTypes.func,
+};
+
 /**
  * Update hover style for the speficied styleId.
  *
@@ -113,36 +158,7 @@ const hasPrevious = (list, currentIndex) => currentIndex - 1 >= 0;
  * the selected option.
  */
 function sanitizeSelectedOptionWrapperProps(properties) {
-  return omit(properties, [
-    'onClick',
-    'style',
-    'className',
-    'ref',
-    'shouldPositionOptions',
-    'positionOptions',
-    'focusStyle',
-    'hoverStyle',
-    'activeStyle',
-    'wrapperStyle',
-    'menuStyle',
-    'caretToOpenStyle',
-    'caretToCloseStyle',
-    'disabledCaretToOpenStyle',
-    'value',
-    'defaultValue',
-    'onUpdate',
-    'valueLink',
-    'role',
-    'aria-expanded',
-    'id',
-    'onTouchStart',
-    'onTouchEnd',
-    'onTouchCancel',
-    'onMouseDown',
-    'onMouseUp',
-    'disabledStyle',
-    'disabledHoverStyle',
-  ]);
+  return omit(properties, Object.keys(selectPropTypes));
 }
 
 /**
@@ -256,50 +272,7 @@ export default class Select extends Component {
 
   static displayName = 'Select';
 
-  static propTypes = {
-    children: validateChildrenAreOptionsAndMaximumOnePlaceholder,
-    value: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date),
-    ]),
-    defaultValue: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.string,
-      PropTypes.number,
-    ]),
-    onUpdate: PropTypes.func,
-    valueLink: PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      requestChange: PropTypes.func.isRequired,
-    }),
-    className: PropTypes.string,
-    shouldPositionOptions: PropTypes.bool,
-    positionOptions: PropTypes.func,
-    style: PropTypes.object,
-    focusStyle: PropTypes.object,
-    hoverStyle: PropTypes.object,
-    activeStyle: PropTypes.object,
-    wrapperStyle: PropTypes.object,
-    menuStyle: PropTypes.object,
-    caretToOpenStyle: PropTypes.object,
-    caretToCloseStyle: PropTypes.object,
-    wrapperProps: PropTypes.object,
-    menuProps: PropTypes.object,
-    caretProps: PropTypes.object,
-    disabled: PropTypes.bool,
-    disabledStyle: PropTypes.object,
-    disabledHoverStyle: PropTypes.object,
-    disabledCaretToOpenStyle: PropTypes.object,
-    id: PropTypes.string,
-    onClick: PropTypes.func,
-    onTouchCancel: PropTypes.func,
-    onMouseDown: PropTypes.func,
-    onMouseUp: PropTypes.func,
-    onTouchEnd: PropTypes.func,
-    onTouchStart: PropTypes.func,
-  };
+  static propTypes = selectPropTypes;
 
   static childContextTypes = {
     isDisabled: PropTypes.bool.isRequired,

--- a/src/components/Separator.js
+++ b/src/components/Separator.js
@@ -2,11 +2,19 @@ import React, { Component, PropTypes } from 'react';
 import { omit } from '../utils/helpers';
 import style from '../style/separator';
 
+const separatorPropTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  style: PropTypes.object,
+};
+
 /**
  * Returns an object with properties that are relevant for the wrapping div.
  */
 function sanitizeChildProps(properties) {
-  return omit(properties, ['style']);
+  return omit(properties, Object.keys(separatorPropTypes));
 }
 
 /**
@@ -25,13 +33,7 @@ export default class Separator extends Component {
 
   static displayName = 'Separator';
 
-  static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node,
-    ]),
-    style: PropTypes.object,
-  };
+  static propTypes = separatorPropTypes;
 
   /**
    * Update the childProperties based on the updated properties passed to the

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -8,6 +8,29 @@ import style from '../style/text-input';
 
 const newLineRegex = /[\r\n]/g;
 
+const textInputPropTypes = {
+  className: PropTypes.string,
+  minHeight: PropTypes.number,
+  maxHeight: PropTypes.number,
+  minRows: PropTypes.number,
+  maxRows: PropTypes.number,
+  style: PropTypes.object,
+  hoverStyle: PropTypes.object,
+  focusStyle: PropTypes.object,
+  allowNewLine: PropTypes.bool,
+  disabled: PropTypes.bool,
+  disabledStyle: PropTypes.object,
+  disabledHoverStyle: PropTypes.object,
+  onUpdate: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  value: PropTypes.string,
+  defaultValue: PropTypes.string,
+  valueLink: PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    requestChange: PropTypes.func.isRequired,
+  }),
+};
+
 /**
  * Returns an object with properties that are relevant for the TextInput's textarea.
  *
@@ -15,21 +38,7 @@ const newLineRegex = /[\r\n]/g;
  * passed down to the textarea, but made available through this component.
  */
 function sanitizeChildProps(properties) {
-  const childProps = omit(properties, [
-    'valueLink',
-    'onUpdate',
-    'onKeyDown',
-    'minHeight',
-    'maxHeight',
-    'minRows',
-    'maxRows',
-    'className',
-    'style',
-    'hoverStyle',
-    'focusStyle',
-    'disabledStyle',
-    'disabledHoverStyle',
-  ]);
+  const childProps = omit(properties, Object.keys(textInputPropTypes));
   if (typeof properties.valueLink === 'object') {
     childProps.value = properties.valueLink.value;
   }
@@ -116,26 +125,7 @@ export default class TextInput extends Component {
 
   static displayName = 'TextInput';
 
-  static propTypes = {
-    className: PropTypes.string,
-    minHeight: PropTypes.number,
-    maxHeight: PropTypes.number,
-    minRows: PropTypes.number,
-    maxRows: PropTypes.number,
-    style: PropTypes.object,
-    hoverStyle: PropTypes.object,
-    focusStyle: PropTypes.object,
-    allowNewLine: PropTypes.bool,
-    disabled: PropTypes.bool,
-    disabledStyle: PropTypes.object,
-    disabledHoverStyle: PropTypes.object,
-    onUpdate: PropTypes.func,
-    onKeyDown: PropTypes.func,
-    valueLink: PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      requestChange: PropTypes.func.isRequired,
-    }),
-  };
+  static propTypes = textInputPropTypes;
 
   static defaultProps = {
     allowNewLine: false,
@@ -262,6 +252,7 @@ export default class TextInput extends Component {
         className={ unionClassNames(this.props.className, this._styleId) }
         onChange={ this._onChange }
         onKeyDown={ this._onKeyDown }
+        disabled={ this.props.disabled }
         { ...this.textareaProps }
       />
     );

--- a/src/components/Toggle.js
+++ b/src/components/Toggle.js
@@ -9,27 +9,98 @@ import { requestAnimationFrame, cancelAnimationFrame } from '../utils/animation-
 import unionClassNames from '../utils/union-class-names';
 import Choice from '../components/Choice';
 
+/**
+ * Verifies that the children is an array containing only two choices with a
+ * different value.
+ */
+function validateChoices(props, propName, componentName) {
+  const propValue = props[propName];
+  if (!propValue) {
+    return undefined;
+  }
+
+  if (!Array.isArray(propValue) || propValue.length !== 2) {
+    return new Error(`Invalid ${propName} supplied to \`${componentName}\`, expected exactly two Choice components.`);
+  }
+
+  for (let i = 0; i < propValue.length; ++i) {
+    const item = propValue[i];
+    if (!item || !isComponentOfType(Choice, item)) {
+      return new Error(`Invalid ${propName}[${i}] supplied to \`${componentName}\`, expected a Choice component from Belle.`);
+    }
+  }
+
+  if (first(propValue).props.value === last(propValue).props.value) {
+    return new Error(`Invalid ${propName} supplied to \`${componentName}\`, expected different value properties for the provided Choice components.`);
+  }
+
+  return undefined;
+}
+
+const togglePropTypes = {
+  activeHandleStyle: PropTypes.object,
+  children: validateChoices,
+  className: PropTypes.string,
+  defaultValue: PropTypes.bool,
+  disabled: PropTypes.bool,
+  disabledHandleStyle: PropTypes.object,
+  disabledStyle: PropTypes.object,
+  firstChoiceProps: PropTypes.object,
+  firstChoiceStyle: PropTypes.shape({
+    width: PropTypes.number,
+  }),
+  focusStyle: PropTypes.object,
+  handleProps: PropTypes.shape({
+    onMouseDown: PropTypes.func,
+    onMouseMove: PropTypes.func,
+    onMouseUp: PropTypes.func,
+    onMouseLeave: PropTypes.func,
+    onTouchStart: PropTypes.func,
+    onTouchMove: PropTypes.func,
+    onTouchEnd: PropTypes.func,
+    onTouchCancel: PropTypes.func,
+  }),
+  handleStyle: PropTypes.shape({
+    height: PropTypes.number,
+    width: PropTypes.number,
+  }),
+  hoverHandleStyle: PropTypes.object,
+  onBlur: PropTypes.func,
+  onUpdate: PropTypes.func,
+  onFocus: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  onMouseDown: PropTypes.func,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  onMouseUp: PropTypes.func,
+  onTouchStart: PropTypes.func,
+  secondChoiceProps: PropTypes.object,
+  secondChoiceStyle: PropTypes.shape({
+    width: PropTypes.number,
+  }),
+  sliderProps: PropTypes.shape({
+    onClick: PropTypes.func,
+    onTouchStart: PropTypes.func,
+    onTouchMove: PropTypes.func,
+    onTouchEnd: PropTypes.func,
+    onTouchCancel: PropTypes.func,
+  }),
+  sliderStyle: PropTypes.object,
+  sliderWrapperProps: PropTypes.object,
+  sliderWrapperStyle: PropTypes.object,
+  style: PropTypes.shape({
+    width: PropTypes.number,
+  }),
+  value: PropTypes.bool,
+  valueLink: PropTypes.shape({
+    value: PropTypes.bool.isRequired,
+    requestChange: PropTypes.func.isRequired,
+  }),
+  wrapperProps: PropTypes.object,
+};
+
 function sanitizeChildProps(properties) {
-  return omit(properties, [
-    'className',
-    'defaultValue',
-    'firstChoiceProps',
-    'focusStyle',
-    'handleProps',
-    'onFocus',
-    'onBlur',
-    'onUpdate',
-    'onMouseDown',
-    'onMouseLeave',
-    'onMouseUp',
-    'onTouchStart',
-    'secondChoiceProps',
-    'sliderProps',
-    'sliderWrapperProps',
-    'style',
-    'tabIndex',
-    'value',
-  ]);
+  return omit(properties, Object.keys(togglePropTypes));
 }
 
 function sanitizeSliderProps(properties) {
@@ -70,37 +141,6 @@ function sanitizeHandleProps(properties) {
     'ref',
     'style',
   ]);
-}
-
-/**
- * Verifies that the provided property is a Choice from Belle.
- */
-function choicePropType(props, propName, componentName) {
-  if (!(props[propName] && isComponentOfType(Choice, props[propName]))) {
-    return new Error(`Invalid children supplied to \`${componentName}\`, expected a Choice component from Belle.`);
-  }
-
-  return undefined;
-}
-
-/**
- * Verifies that the children is an array containing only two choices with a
- * different value.
- */
-function validateChoices(props, propName, componentName) {
-  const error = PropTypes.arrayOf(choicePropType)(props, propName, componentName);
-  if (error) return error;
-
-  if (props.children && props.children.length !== 2) {
-    return new Error(`Invalid children supplied to \`${componentName}\`, expected exactly two Choice components.`);
-  }
-
-  if (props.children &&
-      first(props.children).props.value === last(props.children).props.value) {
-    return new Error(`Invalid children supplied to \`${componentName}\`, expected different value properties for the provided Choice components.`);
-  }
-
-  return undefined;
 }
 
 /**
@@ -183,67 +223,7 @@ export default class Toggle extends Component {
 
   static displayName = 'Toggle';
 
-  static propTypes = {
-    activeHandleStyle: PropTypes.object,
-    children: validateChoices,
-    className: PropTypes.string,
-    defaultValue: PropTypes.bool,
-    disabled: PropTypes.bool,
-    disabledHandleStyle: PropTypes.object,
-    disabledStyle: PropTypes.object,
-    firstChoiceProps: PropTypes.object,
-    firstChoiceStyle: PropTypes.shape({
-      width: PropTypes.number,
-    }),
-    focusStyle: PropTypes.object,
-    handleProps: PropTypes.shape({
-      onMouseDown: PropTypes.func,
-      onMouseMove: PropTypes.func,
-      onMouseUp: PropTypes.func,
-      onMouseLeave: PropTypes.func,
-      onTouchStart: PropTypes.func,
-      onTouchMove: PropTypes.func,
-      onTouchEnd: PropTypes.func,
-      onTouchCancel: PropTypes.func,
-    }),
-    handleStyle: PropTypes.shape({
-      height: PropTypes.number,
-      width: PropTypes.number,
-    }),
-    hoverHandleStyle: PropTypes.object,
-    onBlur: PropTypes.func,
-    onUpdate: PropTypes.func,
-    onFocus: PropTypes.func,
-    onKeyDown: PropTypes.func,
-    onMouseDown: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    onMouseUp: PropTypes.func,
-    onTouchStart: PropTypes.func,
-    secondChoiceProps: PropTypes.object,
-    secondChoiceStyle: PropTypes.shape({
-      width: PropTypes.number,
-    }),
-    sliderProps: PropTypes.shape({
-      onClick: PropTypes.func,
-      onTouchStart: PropTypes.func,
-      onTouchMove: PropTypes.func,
-      onTouchEnd: PropTypes.func,
-      onTouchCancel: PropTypes.func,
-    }),
-    sliderStyle: PropTypes.object,
-    sliderWrapperProps: PropTypes.object,
-    sliderWrapperStyle: PropTypes.object,
-    style: PropTypes.shape({
-      width: PropTypes.number,
-    }),
-    value: PropTypes.bool,
-    valueLink: PropTypes.shape({
-      value: PropTypes.bool.isRequired,
-      requestChange: PropTypes.func.isRequired,
-    }),
-    wrapperProps: PropTypes.object,
-  };
+  static propTypes = togglePropTypes;
 
   static defaultProps = {
     disabled: false,

--- a/src/utils/calculate-textarea-height.js
+++ b/src/utils/calculate-textarea-height.js
@@ -1,6 +1,10 @@
 /* jscs:disable disallowSpacesInsideTemplateStringPlaceholders */
 
-import { canUseDOM } from 'exenv';
+import { canUseDOM as exenvCanUseDOM } from 'exenv';
+
+// our height calculation logic is not compatible with jsdom
+const isNodeTest = typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
+const canUseDOM = exenvCanUseDOM && !isNodeTest;
 
 let hiddenTextarea;
 const computedStyleCache = {};


### PR DESCRIPTION
The goal of this patch is to resolve warnings present when using Belle in a React 15.x codebase.
This patch should not change the behaviour of Belle.

Details:

 - tests, docs, and examples: upgraded to React 15.x
 - docs: upgraded to React Router 2.5.2 for compatibility with React 15.x
   (see https://github.com/ReactTraining/react-router/issues/3695)
 - src, tests, docs, and examples: fixed various warnings introduced throughout React 15.x
 - tests: upgraded Jest for compatibility with Node 6 (https://github.com/facebook/jest/issues/1088)

Testing:

 - verified that there were no React-related warnings in tests, docs, and examples
 - browsed docs and examples in Chrome and FF