### PR TITLE
IE11 workaround

### DIFF
--- a/src/components/SelectItem.js
+++ b/src/components/SelectItem.js
@@ -48,7 +48,7 @@ export default class SelectItem extends Component {
   render() {
     return (
       <li
-        onClick={ this._onClick }
+        onMouseDown={ this._onClick }
         onTouchStart={ this._onTouchStart }
         onTouchMove={ this._onTouchMove }
         onTouchEnd={ this._onTouchEnd }


### PR DESCRIPTION
On Internet Explorer 11, the `onBlur` event is triggered before the `onClick` event occurs. `onMouseDown` prevents this behaviour.
