### PR TITLE
Update changelog and bump version to 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+## 3.0.2 - 2017-05-30
+
+- Removed duplicate declaration of style property in component Day [#336](https://github.com/nikgraf/belle/pull/336)
+
 ## 3.0.1 - 2017-01-16
 
 - [Select] Fixed issue with Internet Explorer 11. The onBlur event is triggered before the onClick event occurs. Using onMouseDown resolved it. [#333](https://github.com/nikgraf/belle/pull/333)

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "belleDocumentation",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Docuemtation for Belle",
   "author": {
     "name": "Nik Graf",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "belleExamples",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Playground for using & developing Belle components",
   "author": {
     "name": "Nik Graf",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "belle",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Configurable React Components with great UX",
   "author": {
     "name": "Nik Graf",


### PR DESCRIPTION
Hi,

It it possible to publish the new version on NPM so that we could benefit from this patch #336 ?

I have a weird bug leading my website not to work on Internet Explorer 11 because of this.

<img width="529" alt="screen shot 2017-05-30 at 4 41 42 pm" src="https://cloud.githubusercontent.com/assets/10377736/26588919/f468a4f6-4556-11e7-897d-806003fc8675.png">
