### PR TITLE
Update uniqueId for ensure the uniqueness

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -384,7 +384,8 @@ export function flattenReactChildren(children) {
 }
 
 export function uniqueId() {
-  return Math.floor((1 + Math.random()) * 0x10000)
-    .toString(16)
-    .substring(1);
+  return 'xxxxxxxx-xxxx-4xxx-yxxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
 }


### PR DESCRIPTION
The older method relies on `Math.Random` method which doesn't able to ensure the uniqueness of the generated ID.  The requested method loosely based on  [RFC4122 ](https://www.ietf.org/rfc/rfc4122.txt), however, this doesn't guarantee to give a unique ID always, when compared to the previous method it gives better results.